### PR TITLE
Add PASS support as per RFC1459

### DIFF
--- a/config.go
+++ b/config.go
@@ -13,6 +13,7 @@ type Config struct {
 		Server        string
 		Port          int
 		Nick          string
+		Password      string
 		Channel       string
 	}
 	Mattermost struct {

--- a/matterbridge.go
+++ b/matterbridge.go
@@ -41,6 +41,9 @@ func (b *Bridge) createIRC(name string) *irc.Connection {
 	i := irc.IRC(b.Config.IRC.Nick, b.Config.IRC.Nick)
 	i.UseTLS = b.Config.IRC.UseTLS
 	i.TLSConfig = &tls.Config{InsecureSkipVerify: b.Config.IRC.SkipTLSVerify}
+	if b.Config.IRC.Password != "" {
+		i.Password = b.Config.IRC.Password
+	}
 	i.Connect(b.Config.IRC.Server + ":" + strconv.Itoa(b.Config.IRC.Port))
 	time.Sleep(time.Second)
 	log.Println("Joining", b.Config.IRC.Channel, "as", b.Config.IRC.Nick)


### PR DESCRIPTION
Provide a connection password via the protocol's PASS command.

Imported irc.go supports it as a simple parameter:
https://github.com/thoj/go-ircevent/blob/master/irc.go#L381

See https://tools.ietf.org/html/rfc1459#section-4.1 for full details.