### PR TITLE
Add config option to prefix messages (IRC->MM) with nick

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ SkipTLSVerify=true
 nick="matterbot"
 channel="#matterbridge"
 UseSlackCircumfix=false
+#whether to prefix messages from IRC to mattermost with the sender's nick. Useful if username overrides for incoming webhooks isn't enabled on the mattermost server
+PrefixMessagesWithNick=false
 
 [mattermost]
 #url is your incoming webhook url (account settings - integrations - incoming webhooks)

--- a/config.go
+++ b/config.go
@@ -8,14 +8,15 @@ import (
 
 type Config struct {
 	IRC struct {
-		UseTLS            bool
-		SkipTLSVerify     bool
-		Server            string
-		Port              int
-		Nick              string
-		Password          string
-		Channel           string
-		UseSlackCircumfix bool
+		UseTLS                 bool
+		SkipTLSVerify          bool
+		Server                 string
+		Port                   int
+		Nick                   string
+		Password               string
+		Channel                string
+		UseSlackCircumfix      bool
+		PrefixMessagesWithNick bool
 	}
 	Mattermost struct {
 		URL           string

--- a/matterbridge.conf.sample
+++ b/matterbridge.conf.sample
@@ -6,6 +6,7 @@ SkipTLSVerify=true
 nick="matterbot"
 channel="#matterbridge"
 UseSlackCircumfix=false
+PrefixMessagesWithNick=false
 
 [mattermost]
 url="http://yourdomain/hooks/yourhookkey"

--- a/matterbridge.go
+++ b/matterbridge.go
@@ -92,8 +92,12 @@ func (b *Bridge) SendType(nick string, message string, channel string, mtype str
 	matterMessage := matterhook.OMessage{IconURL: b.Config.Mattermost.IconURL}
 	matterMessage.Channel = channel
 	matterMessage.UserName = nick
-	matterMessage.Text = message
 	matterMessage.Type = mtype
+	if (b.Config.IRC.PrefixMessagesWithNick) {
+		matterMessage.Text = nick + ": " + message
+	} else {
+		matterMessage.Text = message
+	}
 	err := b.m.Send(matterMessage)
 	if err != nil {
 		log.Println(err)


### PR DESCRIPTION
If username overriding isn't enabled on the Mattermost server, this is
required for Mattermost users to see who sent a message from IRC.