### PR TITLE
Allow PrefixMessagesWithNick on Telegram

### DIFF
--- a/bridge/telegram/telegram.go
+++ b/bridge/telegram/telegram.go
@@ -57,7 +57,12 @@ func (b *Btelegram) Send(msg config.Message) error {
 	if err != nil {
 		return err
 	}
-	m := tgbotapi.NewMessage(chatid, msg.Text)
+
+	message := msg.Text
+	if b.Config.PrefixMessagesWithNick {
+		message = msg.Username + " " + message
+	}
+	m := tgbotapi.NewMessage(chatid, message)
 	_, err = b.c.Send(m)
 	return err
 }


### PR DESCRIPTION
This makes the PrefixMessagesWithNick setting work for messages relayed
to Telegram, similar to how they work for messages relayed to mattermost
(it is in fact copied from the mattermost bridge implementation).

I believe this logic should be moved up the stack and not left to
individual bridge implementations, but adding it here like this made it
quickly work for my use-case (I don't have the time to dig in deeper and
refactor everything).