### PR TITLE
Handle SkipTLSVerify for XMPP client

### DIFF
--- a/bridge/xmpp/xmpp.go
+++ b/bridge/xmpp/xmpp.go
@@ -4,6 +4,7 @@ import (
 	"github.com/42wim/matterbridge/bridge/config"
 	log "github.com/Sirupsen/logrus"
 	"github.com/mattn/go-xmpp"
+	"crypto/tls"
 
 	"strings"
 	"time"
@@ -58,12 +59,16 @@ func (b *Bxmpp) Send(msg config.Message) error {
 }
 
 func (b *Bxmpp) createXMPP() (*xmpp.Client, error) {
+	tc := new(tls.Config)
+	tc.InsecureSkipVerify = b.Config.SkipTLSVerify
 	options := xmpp.Options{
 		Host:     b.Config.Server,
 		User:     b.Config.Jid,
 		Password: b.Config.Password,
 		NoTLS:    true,
 		StartTLS: true,
+		TLSConfig: tc,
+
 		//StartTLS:      false,
 		Debug:                        true,
 		Session:                      true,

--- a/matterbridge.toml.sample
+++ b/matterbridge.toml.sample
@@ -97,6 +97,11 @@ Muc="conference.jabber.example.com"
 #REQUIRED
 Nick="xmppbot"
 
+#Enable to not verify the certificate on your xmpp server.
+#e.g. when using selfsigned certificates
+#OPTIONAL (default false)
+SkipTLSVerify=true
+
 #Nicks you want to ignore. 
 #Messages from those users will not be sent to other bridges.
 #OPTIONAL


### PR DESCRIPTION
This PR is similiar to #81 but makes the SkipTLSVerify option configurable at runtime.

This makes it possible to use matterbridge with self-signed certificates. Actually it would be better to specify custom trust anchor, but in the meantime this works if used in a trusted network.