### PR TITLE
Add Compatibility for Cisco Jabber

### DIFF
--- a/bridge/xmpp/xmpp.go
+++ b/bridge/xmpp/xmpp.go
@@ -119,7 +119,7 @@ func (b *Bxmpp) handleXmpp() error {
 			var channel, nick string
 			if v.Type == "groupchat" {
 				s := strings.Split(v.Remote, "@")
-				if len(s) == 2 {
+				if len(s) >= 2 {
 					channel = s[0]
 				}
 				s = strings.Split(s[1], "/")


### PR DESCRIPTION
In our Cisco Jabber Environment, v.Remote contains the Users eMail Address.
e.g:
v.Remote:
ictxbridge16452221619216@conference-2-standaloneclusterd118c.corp.com/john.doe@corp.com/jabber_24111

This PR will fix the extraction of the correct Channel Name
