### PR TITLE
remove second flag.Parse()

### DIFF
--- a/matterbridge.go
+++ b/matterbridge.go
@@ -34,7 +34,6 @@ func main() {
 		fmt.Printf("version: %s %s\n", version, githash)
 		return
 	}
-	flag.Parse()
 	if *flagDebug {
 		log.Info("Enabling debug")
 		log.SetLevel(log.DebugLevel)


### PR DESCRIPTION
flag.Parse() is already being called on line 28 https://github.com/42wim/matterbridge/blob/master/matterbridge.go#L28
and there is no need for calling it again