### PR TITLE
Add webhook posting mode for discord.

### DIFF
--- a/bridge/config/config.go
+++ b/bridge/config/config.go
@@ -77,6 +77,7 @@ type Protocol struct {
 	UseSASL                bool   // IRC
 	UseTLS                 bool   // IRC
 	UseFirstName           bool   // telegram
+	WebhookURL	       string // discord
 }
 
 type ChannelOptions struct {

--- a/matterbridge.toml.sample
+++ b/matterbridge.toml.sample
@@ -454,6 +454,10 @@ Server="yourservername"
 #OPTIONAL (default false)
 ShowEmbeds=false
 
+#Specify WebhookURL. If given, will relay messages using the Webhook, which gives a better look to messages.
+#OPTIONAL (default empty)
+WebhookURL="Yourwebhooktokenhere"
+
 #Disable sending of edits to other bridges
 #OPTIONAL (default false)
 EditDisable=false


### PR DESCRIPTION
Using it implies to configure a Webhook on discord and set the parameter :
- WebhookURL (New parameter, discord-specific)

Discord API does not allow to change the name of the user posting, but webhooks does.
This makes the relay much more elegant, even if we might lose some more advanced features.

Discord API does not allow to change the name of the user posting, but webhooks does.
This makes the relay much more elegant, even if we might lose some more advanced features.

Resulting relays looks like this :
<img width="262" alt="capture d ecran 2017-06-23 a 20 32 44" src="https://user-images.githubusercontent.com/418817/27495701-58bd0e74-5853-11e7-902d-923f8c7febfa.png">
Instead of looking like this :
<img width="282" alt="capture d ecran 2017-06-23 a 20 36 22" src="https://user-images.githubusercontent.com/418817/27495792-acbf5ee6-5853-11e7-8ad7-a68513ef0b88.png">



Signed-off-by: saury07 <sacha.aury@gmail.com>