### PR TITLE
Suppress parent message when child message is received

### DIFF
--- a/bridge/slack/slack.go
+++ b/bridge/slack/slack.go
@@ -14,11 +14,13 @@ import (
 )
 
 type MMMessage struct {
-	Text     string
-	Channel  string
-	Username string
-	UserID   string
-	Raw      *slack.MessageEvent
+	Text      string
+	Channel   string
+	Username  string
+	UserID    string
+	Thread_ts string
+	Ts	  string
+	Raw       *slack.MessageEvent
 }
 
 type Bslack struct {
@@ -219,6 +221,9 @@ func (b *Bslack) handleSlack() {
 	for message := range mchan {
 		// do not send messages from ourself
 		if b.Config.WebhookURL == "" && b.Config.WebhookBindAddress == "" && message.Username == b.si.User.Name {
+			continue
+		}
+		if message.Ts == message.Thread_ts {
 			continue
 		}
 		texts := strings.Split(message.Text, "\n")

--- a/bridge/slack/slack.go
+++ b/bridge/slack/slack.go
@@ -14,11 +14,11 @@ import (
 )
 
 type MMMessage struct {
-	Text      string
-	Channel   string
-	Username  string
-	UserID    string
-	Raw       *slack.MessageEvent
+	Text     string
+	Channel  string
+	Username string
+	UserID   string
+	Raw      *slack.MessageEvent
 }
 
 type Bslack struct {

--- a/bridge/slack/slack.go
+++ b/bridge/slack/slack.go
@@ -18,8 +18,6 @@ type MMMessage struct {
 	Channel   string
 	Username  string
 	UserID    string
-	Thread_ts string
-	Ts	  string
 	Raw       *slack.MessageEvent
 }
 
@@ -223,9 +221,6 @@ func (b *Bslack) handleSlack() {
 		if b.Config.WebhookURL == "" && b.Config.WebhookBindAddress == "" && message.Username == b.si.User.Name {
 			continue
 		}
-		if message.Ts == message.Thread_ts {
-			continue
-		}
 		texts := strings.Split(message.Text, "\n")
 		for _, text := range texts {
 			text = b.replaceURL(text)
@@ -244,7 +239,7 @@ func (b *Bslack) handleSlackClient(mchan chan *MMMessage) {
 			// ignore first message
 			if count > 0 {
 				flog.Debugf("Receiving from slackclient %#v", ev)
-				if !b.Config.EditDisable && ev.SubMessage != nil {
+				if !b.Config.EditDisable && ev.SubMessage != nil && ev.SubMessage.ThreadTimestamp != ev.SubMessage.Timestamp {
 					flog.Debugf("SubMessage %#v", ev.SubMessage)
 					ev.User = ev.SubMessage.User
 					ev.Text = ev.SubMessage.Text + b.Config.EditSuffix


### PR DESCRIPTION
When a thread is started in Slack and a user makes a comment on the thread, matterbridge sends the original parent message again on each child comment. This change suppresses that.

This is addresses #217.