### PR TITLE
Added new file_ids parameter for Mattermost outgoing webhook

### DIFF
--- a/matterhook/matterhook.go
+++ b/matterhook/matterhook.go
@@ -43,6 +43,7 @@ type IMessage struct {
 	ServiceId   string `schema:"service_id"`
 	Text        string `schema:"text"`
 	TriggerWord string `schema:"trigger_word"`
+	FileID      string `schema:"file_id"`
 }
 
 // Client for Mattermost.

--- a/matterhook/matterhook.go
+++ b/matterhook/matterhook.go
@@ -43,7 +43,7 @@ type IMessage struct {
 	ServiceId   string `schema:"service_id"`
 	Text        string `schema:"text"`
 	TriggerWord string `schema:"trigger_word"`
-	FileID      string `schema:"file_id"`
+	FileIDs     string `schema:"file_ids"`
 }
 
 // Client for Mattermost.


### PR DESCRIPTION
As of version 4.1.0 it seems as if Mattermost is now including a file_ids parameter in the outgoing webhook requests. 

This adds the parameter to the IMessage structure so that schema doesn't complain and outgoing webhook messages function again.