### PR TITLE
[general] settings should be default, not total override (specifically RemoteNickFormat)

### DIFF
--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -243,9 +243,9 @@ func (gw *Gateway) ignoreMessage(msg *config.Message) bool {
 func (gw *Gateway) modifyUsername(msg config.Message, dest *bridge.Bridge) string {
 	br := gw.Bridges[msg.Account]
 	msg.Protocol = br.Protocol
-	nick := gw.Config.General.RemoteNickFormat
+  nick := dest.Config.RemoteNickFormat
 	if nick == "" {
-		nick = dest.Config.RemoteNickFormat
+    nick = gw.Config.General.RemoteNickFormat
 	}
 	if len(msg.Username) > 0 {
 		// fix utf-8 issue #193

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -243,9 +243,9 @@ func (gw *Gateway) ignoreMessage(msg *config.Message) bool {
 func (gw *Gateway) modifyUsername(msg config.Message, dest *bridge.Bridge) string {
 	br := gw.Bridges[msg.Account]
 	msg.Protocol = br.Protocol
-  nick := dest.Config.RemoteNickFormat
+	nick := dest.Config.RemoteNickFormat
 	if nick == "" {
-    nick = gw.Config.General.RemoteNickFormat
+		nick = gw.Config.General.RemoteNickFormat
 	}
 	if len(msg.Username) > 0 {
 		// fix utf-8 issue #193

--- a/matterbridge.toml.sample
+++ b/matterbridge.toml.sample
@@ -773,7 +773,7 @@ RemoteNickFormat="{NICK}"
 ###################################################################
 #General configuration
 ###################################################################
-#Settings here override specific settings for each protocol
+# Settings here are defaults that each protocol can override
 [general]
 #RemoteNickFormat defines how remote users appear on this bridge 
 #The string "{NICK}" (case sensitive) will be replaced by the actual nick / username.


### PR DESCRIPTION
If you have a configuration problem, please first try to create a basic configuration following the instructions on [the wiki](https://github.com/42wim/matterbridge/wiki/How-to-create-your-config) before filing an issue.

Please answer the following questions. 

### Which version of matterbridge are you using?
v1.3.0

### If you're having problems with mattermost please specify mattermost version. 


### Please describe the expected behavior.
Expect that setting `RemoteNickFormat` in `[general]` would be default, and that setting in one specific protocol would override that.

### Please describe the actual behavior. 
#### Use logs from running ```matterbridge -debug``` if possible.

Instead, seems that setting `RemoteNickFormat` in `[general]` supercedes everywhere else.

This would seem to be intended behaviour right now:
https://github.com/42wim/matterbridge/blob/master/matterbridge.toml.sample#L776

### Any steps to reproduce the behavior?


### Please add your configuration file 
#### (be sure to exclude or anonymize private data (tokens/passwords))

```
[general]
RemoteNickFormat="{NICK}@{BRIDGE}"

# ...

[slack.hacklabto]
Token="${SLACK_HACKLABTO_TOKEN}" # bot user
RemoteNickFormat="{NICK}@{PROTOCOL}"

[telegram.hacklabto]
Token="${TELEGRAM_TOKEN}"
RemoteNickFormat="{NICK}@{PROTOCOL}: "
```

![telegram screenshot from slack](https://imgur.com/GANI4rk.png)