### PR TITLE
Remove angle-brackets from urls coming out of slack

### DIFF
--- a/bridge/slack/slack.go
+++ b/bridge/slack/slack.go
@@ -410,7 +410,7 @@ func (b *Bslack) replaceMention(text string) string {
 }
 
 func (b *Bslack) replaceURL(text string) string {
-	results := regexp.MustCompile(`<(.*?)\|.*?>`).FindAllStringSubmatch(text, -1)
+	results := regexp.MustCompile(`<(.*?)(\|.*?)?>`).FindAllStringSubmatch(text, -1)
 	for _, r := range results {
 		text = strings.Replace(text, r[0], r[1], -1)
 	}


### PR DESCRIPTION
### Which version of matterbridge are you using?
v1.3.1

Would it be a sensible improvement to stop adding (or rather, to start stripping, if that's the case) the angle brackets from slack-slack bridge messages? It seems to prevent slack for hyperlinking and unfurling.

![screenshot](https://imgur.com/1XOWjPX.png)

I suspect it's happening here, but please let me know if it might exist elsewhere:
https://github.com/42wim/matterbridge/blob/master/bridge/slack/slack.go#L413