### PR TITLE
Slack channels should be resolved to human-readable format (when piped into Telegram)

### DIFF
--- a/bridge/slack/slack.go
+++ b/bridge/slack/slack.go
@@ -340,6 +340,7 @@ func (b *Bslack) handleSlackClient(mchan chan *MMMessage) {
 			}
 			m.Raw = ev
 			m.Text = b.replaceMention(m.Text)
+			m.Text = b.replaceChannel(m.Text)
 			// when using webhookURL we can't check if it's our webhook or not for now
 			if ev.BotID != "" && b.Config.WebhookURL == "" {
 				bot, err := b.rtm.GetBotInfo(ev.BotID)
@@ -386,6 +387,7 @@ func (b *Bslack) handleMatterHook(mchan chan *MMMessage) {
 		m.Username = message.UserName
 		m.Text = message.Text
 		m.Text = b.replaceMention(m.Text)
+		m.Text = b.replaceChannel(m.Text)
 		m.Channel = message.ChannelName
 		if m.Username == "slackbot" {
 			continue
@@ -410,7 +412,14 @@ func (b *Bslack) replaceMention(text string) string {
 	results := regexp.MustCompile(`<@([a-zA-z0-9]+)>`).FindAllStringSubmatch(text, -1)
 	for _, r := range results {
 		text = strings.Replace(text, "<@"+r[1]+">", "@"+b.userName(r[1]), -1)
+	}
+	return text
+}
 
+func (b *Bslack) replaceChannel(text string) string {
+	results := regexp.MustCompile(`<#[a-zA-Z0-9]+\|(.+?)>`).FindAllStringSubmatch(text, -1)
+	for _, r := range results {
+		text = strings.Replace(text, r[0], "#"+r[1], -1)
 	}
 	return text
 }


### PR DESCRIPTION
If you have a configuration problem, please first try to create a basic configuration following the instructions on [the wiki](https://github.com/42wim/matterbridge/wiki/How-to-create-your-config) before filing an issue.

Please answer the following questions. 

### Which version of matterbridge are you using?
v1.3.1

### Please describe the expected behavior.
Expect that when relaying messages from Slack to Telegram, the hashed channel names would be displayed in human-readable format

### Please describe the actual behavior. 
Instead

Slack msg: ![screenshot](https://imgur.com/XyHI9j7.png)

How it looks in Telegram: ~~https://imgur.com/XyHI9j7~~ ![screenshot](https://i.imgur.com/GSkUeZL.png)

### Any steps to reproduce the behavior?


### Please add your configuration file 

```
[[gateway]]
name="hacklabto-general"
enable=true
  [[gateway.inout]]
  account="telegram.hacklabto"
  channel="-1001087615555"
  [[gateway.inout]]
  account="slack.hacklabto"
  channel="general"
```
