### PR TITLE
Fix build on go1.9.2

### DIFF
--- a/matterbridge.go
+++ b/matterbridge.go
@@ -27,7 +27,7 @@ func main() {
 	flagGops := flag.Bool("gops", false, "enable gops agent")
 	flag.Parse()
 	if *flagGops {
-		agent.Listen(&agent.Options{})
+		agent.Listen(agent.Options{})
 		defer agent.Close()
 	}
 	if *flagVersion {


### PR DESCRIPTION
```
~/repos/matterbridge (master ✘)✭ ᐅ go build
# _/home/patcon/repos/matterbridge
./matterbridge.go:30:31: cannot use agent.Options literal (type *agent.Options) as type agent.Options in argument to agent.Listen
~/repos/matterbridge (master ✘)✭ ᐅ go version
go version go1.9.2 linux/amd64
~/repos/matterbridge (master ✘)✭ ᐅ 
```

Not sure what's up, but I get this when i try to build. I've got a fix, but I'm not sure the implications of it. Will submit a PR, and perhaps you might have an idea what's going on. (Would love a pointer in the right direction to better understand what's going on here! :) )