### PR TITLE
Slack <=> gitter bridge is confusing machine name with human-readable gitter channel name

### DIFF
--- a/bridge/gitter/gitter.go
+++ b/bridge/gitter/gitter.go
@@ -95,7 +95,7 @@ func (b *Bgitter) JoinChannel(channel config.ChannelInfo) error {
 				flog.Errorf("connection with gitter closed for room %s", room)
 			}
 		}
-	}(stream, room.Name)
+	}(stream, room.URI)
 	return nil
 }
 


### PR DESCRIPTION
here is the config and the two  relevant lines of the debug log:

https://gist.github.com/patcon/14f352962d3d3a60457ca3a3c821ec7f

Seems that my gitter channel is a little effed in the i accidentally named the hacklabto org with a humanfriendly name of "lobby". You can see that here:
https://gitter.im/hacklabto/lobby

url is `hacklabto/lobby`, but channel name is `lobby/lobby` in UI.

In the matterbridge logs, it seems that it is trying to send slack message to lobby/lobby

Will dig in later, but would appreciate a second set of eyes on the logs, in case i'm misinterpretting it :)