### PR TITLE
Convert received IRC channel names to lowercase. Fixes #329

### DIFF
--- a/bridge/irc/irc.go
+++ b/bridge/irc/irc.go
@@ -323,7 +323,7 @@ func (b *Birc) handlePrivMsg(client *girc.Client, event girc.Event) {
 	if event.Source.Name == b.Nick {
 		return
 	}
-	rmsg := config.Message{Username: event.Source.Name, Channel: event.Params[0], Account: b.Account, UserID: event.Source.Ident + "@" + event.Source.Host}
+	rmsg := config.Message{Username: event.Source.Name, Channel: strings.ToLower(event.Params[0]), Account: b.Account, UserID: event.Source.Ident + "@" + event.Source.Host}
 	flog.Debugf("handlePrivMsg() %s %s %#v", event.Source.Name, event.Trailing, event)
 	msg := ""
 	if event.IsAction() {


### PR DESCRIPTION
Convert received IRC channel name to lowercase. Channel name case is specified by IRC user when joining a channel and can be anything. This normalizes all channel names to lowercase (which is what config expects).