### PR TITLE
Allow ShowJoinPart config to work for Slack bridges

### DIFF
--- a/matterbridge.toml.sample
+++ b/matterbridge.toml.sample
@@ -126,7 +126,7 @@ ReplaceNicks=[ ["user--","user"] ]
 RemoteNickFormat="[{PROTOCOL}] <{NICK}> "
 
 #Enable to show users joins/parts from other bridges 
-#Only works hiding/show messages from irc and mattermost bridge for now
+#Currently works for messages from the following bridges: irc, mattermost, slack
 #OPTIONAL (default false)
 ShowJoinPart=false
 


### PR DESCRIPTION
As stated here, this setting only works for IRC and Mattermost right now:

https://github.com/42wim/matterbridge/blob/master/matterbridge.toml.sample#L129