### PR TITLE
Truncate messages sent to IRC based on byte count

### DIFF
--- a/bridge/irc/irc.go
+++ b/bridge/irc/irc.go
@@ -196,8 +196,8 @@ func (b *Birc) Send(msg config.Message) (string, error) {
 	}
 	for _, text := range strings.Split(msg.Text, "\n") {
 		if len(text) > b.Config.MessageLength {
-			for len(text)+len(" <message clipped>") > b.Config.MessageLength {
-				_, size := utf8.DecodeLastRuneInString(text)
+			text = text[:b.Config.MessageLength-len(" <message clipped>")]
+			if r, size := utf8.DecodeLastRuneInString(text); r == utf8.RuneError {
 				text = text[:len(text)-size]
 			}
 			text += " <message clipped>"

--- a/bridge/irc/irc.go
+++ b/bridge/irc/irc.go
@@ -19,6 +19,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode/utf8"
 )
 
 type Birc struct {
@@ -194,9 +195,12 @@ func (b *Birc) Send(msg config.Message) (string, error) {
 		msg.Text = helper.SplitStringLength(msg.Text, b.Config.MessageLength)
 	}
 	for _, text := range strings.Split(msg.Text, "\n") {
-		input := []rune(text)
 		if len(text) > b.Config.MessageLength {
-			text = string(input[:b.Config.MessageLength]) + " <message clipped>"
+			for len(text)+len(" <message clipped>") > b.Config.MessageLength {
+				_, size := utf8.DecodeLastRuneInString(text)
+				text = text[:len(text)-size]
+			}
+			text += " <message clipped>"
 		}
 		if len(b.Local) < b.Config.MessageQueue {
 			if len(b.Local) == b.Config.MessageQueue-1 {


### PR DESCRIPTION
Truncating based on rune count is wrong because 
  - maximum IRC message length is defined in bytes,
  - the code responsible for truncating is executed only if the number of bytes in the message exceeds `b.Config.MessageLength`, which as a result crashes matterbridge when `len(text) > b.Config.MessageLength > len([]rune(text))`.

Example of a message that can be used to reproduce the crash, tested with discord → irc: `あああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああああ`