### PR TITLE
Print list of valid team names when team not found

### DIFF
--- a/matterclient/matterclient.go
+++ b/matterclient/matterclient.go
@@ -190,7 +190,11 @@ func (m *MMClient) Login() error {
 	}
 
 	if m.Team == nil {
-		return errors.New("team not found")
+		validTeamNames := make([]string, len(m.OtherTeams))
+		for i, t := range m.OtherTeams {
+			validTeamNames[i] = t.Team.Name
+		}
+		return fmt.Errorf("Team '%s' not found in %v", m.Credentials.Team, validTeamNames)
 	}
 
 	m.wsConnect()


### PR DESCRIPTION
When attempting to sign in to a team, this PR provides a more informative list of valid team options to choose from in the event that the user's selected team could not be found.