### PR TITLE
Properly set Slack user who initiated slash command

### DIFF
--- a/bridge/slack/slack.go
+++ b/bridge/slack/slack.go
@@ -485,7 +485,7 @@ func (b *Bslack) handleMessageEvent(ev *slack.MessageEvent) (*config.Message, er
 	rmsg := config.Message{Text: ev.Text, Channel: channel.Name, Account: b.Account, ID: "slack " + ev.Timestamp, Extra: make(map[string][]interface{})}
 
 	// find the user id and name
-	if (ev.BotID == "" && ev.SubType != messageDeleted && ev.SubType != "file_comment") || (ev.BotID != "" && ev.Text == "" && ev.Attachments != nil) {
+	if ev.User != "" && ev.SubType != messageDeleted && ev.SubType != "file_comment" {
 		user, err := b.rtm.GetUserInfo(ev.User)
 		if err != nil {
 			return nil, err
@@ -509,7 +509,7 @@ func (b *Bslack) handleMessageEvent(ev *slack.MessageEvent) (*config.Message, er
 	}
 
 	// when using webhookURL we can't check if it's our webhook or not for now
-	if ev.BotID != "" && (b.GetString("WebhookURL") == "" && ev.Attachments == nil) {
+	if rmsg.Username == "" && ev.BotID != "" && b.GetString("WebhookURL") == "" {
 		bot, err := b.rtm.GetBotInfo(ev.BotID)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
This is an attempt to resolve issue #393 by adding a test to see if there is an attachment AND a BotID during the message handler