### PR TITLE
Send attached files to XMPP in different message with OOB data and without body

### DIFF
--- a/bridge/xmpp/xmpp.go
+++ b/bridge/xmpp/xmpp.go
@@ -180,6 +180,7 @@ func (b *Bxmpp) replaceAction(text string) (string, bool) {
 
 // handleUploadFile handles native upload of files
 func (b *Bxmpp) handleUploadFile(msg *config.Message) (string, error) {
+	var urldesc = ""
 	for _, f := range msg.Extra["file"] {
 		fi := f.(config.FileInfo)
 		if fi.Comment != "" {
@@ -189,11 +190,15 @@ func (b *Bxmpp) handleUploadFile(msg *config.Message) (string, error) {
 			msg.Text = fi.URL
 			if fi.Comment != "" {
 				msg.Text = fi.Comment + ": " + fi.URL
+				urldesc = fi.Comment
 			}
 		}
 		_, err := b.xc.Send(xmpp.Chat{Type: "groupchat", Remote: msg.Channel + "@" + b.GetString("Muc"), Text: msg.Username + msg.Text})
 		if err != nil {
 			return "", err
+		}
+		if fi.URL != "" {
+			b.xc.SendOOB(xmpp.Chat{Type: "groupchat", Remote: msg.Channel + "@" + b.GetString("Muc"), Ooburl: fi.URL, Oobdesc: urldesc})
 		}
 	}
 	return "", nil


### PR DESCRIPTION
Conversations can't show inline pictures if there's anything besides URL in the message body.
Workaround this issue by sending one usual message and one message with OOB data and without message body.
The second message should not be shown in the clients without OOB support, so the user won't see the empty message.

go-xmpp modifications are required: https://github.com/matterbridge/go-xmpp/pull/2