### PR TITLE
Fix issue #432 - Avatar spoofing from Slack with uppercase in nick

### DIFF
--- a/bridge/slack/slack.go
+++ b/bridge/slack/slack.go
@@ -268,7 +268,7 @@ func (b *Bslack) handleSlack() {
 		message.Text = html.UnescapeString(message.Text)
 
 		// Add the avatar
-		message.Avatar = b.getAvatar(message.Username)
+		message.Avatar = b.getAvatar(strings.ToLower(message.Username))
 
 		b.Log.Debugf("<= Message is %#v", message)
 		b.Remote <- *message


### PR DESCRIPTION
This fixes the issue #432 