### PR TITLE
Add config option MediaUploadPath

### DIFF
--- a/bridge/config/config.go
+++ b/bridge/config/config.go
@@ -77,7 +77,7 @@ type Protocol struct {
 	MediaDownloadSize      int    // all protocols
 	MediaServerDownload    string
 	MediaServerUpload      string
-	MediaServerPath        string     // Basically MediaServerUpload, but instead of uploading it, just write it to a file on the same server.
+	MediaDownloadPath      string     // Basically MediaServerUpload, but instead of uploading it, just write it to a file on the same server.
 	MessageDelay           int        // IRC, time in millisecond to wait between messages
 	MessageFormat          string     // telegram
 	MessageLength          int        // IRC, max length of a message allowed

--- a/bridge/config/config.go
+++ b/bridge/config/config.go
@@ -2,14 +2,15 @@ package config
 
 import (
 	"bytes"
-	"github.com/fsnotify/fsnotify"
-	log "github.com/sirupsen/logrus"
-	"github.com/spf13/viper"
-	prefixed "github.com/x-cray/logrus-prefixed-formatter"
 	"os"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/fsnotify/fsnotify"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/viper"
+	prefixed "github.com/x-cray/logrus-prefixed-formatter"
 )
 
 const (
@@ -76,6 +77,7 @@ type Protocol struct {
 	MediaDownloadSize      int    // all protocols
 	MediaServerDownload    string
 	MediaServerUpload      string
+	MediaServerPath        string     // Basically MediaServerUpload, but instead of uploading it, just write it to a file on the same server.
 	MessageDelay           int        // IRC, time in millisecond to wait between messages
 	MessageFormat          string     // telegram
 	MessageLength          int        // IRC, max length of a message allowed

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -440,7 +440,8 @@ func (gw *Gateway) handleFiles(msg *config.Message) {
 		fi.Name = fi.Name[0 : len(fi.Name)-len(ext)]
 		fi.Name = reg.ReplaceAllString(fi.Name, "_")
 		fi.Name = fi.Name + ext
-		sha1sum := fmt.Sprintf("%x", sha1.Sum(*fi.Data))
+
+		sha1sum := fmt.Sprintf("%x", sha1.Sum(*fi.Data))[:8]
 
 		if gw.Config.General.MediaServerUpload != "" {
 			// Use MediaServerUpload. Upload using a PUT HTTP request and basicauth.

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -415,70 +415,82 @@ func (gw *Gateway) modifyMessage(msg *config.Message) {
 	}
 }
 
+// handleFiles uploads or places all files on the given msg to the MediaServer and
+// adds the new URL of the file on the MediaServer onto the given msg.
 func (gw *Gateway) handleFiles(msg *config.Message) {
 	reg := regexp.MustCompile("[^a-zA-Z0-9]+")
-	// if we don't have a attachfield or we don't have a mediaserver configured return
+
+	// If we don't have a attachfield or we don't have a mediaserver configured return
 	if msg.Extra == nil || (gw.Config.General.MediaServerUpload == "" && gw.Config.General.MediaServerPath == "") {
 		return
 	}
 
-	// if we actually have files, start uploading them to the mediaserver
-	if len(msg.Extra["file"]) > 0 {
-		client := &http.Client{
-			Timeout: time.Second * 5,
-		}
-		for i, f := range msg.Extra["file"] {
-			fi := f.(config.FileInfo)
-			ext := filepath.Ext(fi.Name)
-			fi.Name = fi.Name[0 : len(fi.Name)-len(ext)]
-			fi.Name = reg.ReplaceAllString(fi.Name, "_")
-			fi.Name = fi.Name + ext
-			sha1sum := fmt.Sprintf("%x", sha1.Sum(*fi.Data))
+	// If we don't have files, nothing to upload.
+	if len(msg.Extra["file"]) == 0 {
+		return
+	}
 
-			durl := gw.Config.General.MediaServerDownload + "/" + sha1sum + "/" + fi.Name
-			if gw.Config.General.MediaServerUpload != "" {
-				url := gw.Config.General.MediaServerUpload + "/" + sha1sum + "/" + fi.Name
+	client := &http.Client{
+		Timeout: time.Second * 5,
+	}
 
-				req, err := http.NewRequest("PUT", url, bytes.NewReader(*fi.Data))
-				if err != nil {
-					flog.Errorf("mediaserver upload failed, could not create request: %#v", err)
-					continue
-				}
+	for i, f := range msg.Extra["file"] {
+		fi := f.(config.FileInfo)
+		ext := filepath.Ext(fi.Name)
+		fi.Name = fi.Name[0 : len(fi.Name)-len(ext)]
+		fi.Name = reg.ReplaceAllString(fi.Name, "_")
+		fi.Name = fi.Name + ext
+		sha1sum := fmt.Sprintf("%x", sha1.Sum(*fi.Data))
 
-				flog.Debugf("mediaserver upload url: %s", url)
+		if gw.Config.General.MediaServerUpload != "" {
+			// Use MediaServerUpload. Upload using a PUT HTTP request and basicauth.
 
-				req.Header.Set("Content-Type", "binary/octet-stream")
-				_, err = client.Do(req)
-				if err != nil {
-					flog.Errorf("mediaserver upload failed, could not Do request: %#v", err)
-					continue
-				}
-			} else {
-				dir := gw.Config.General.MediaServerPath + "/" + sha1sum
-				err := os.Mkdir(dir, os.ModePerm)
-				if err != nil && !os.IsExist(err) {
-					flog.Errorf("mediaserver path failed, could not mkdir: %s %#v", err, err)
-					continue
-				}
+			url := gw.Config.General.MediaServerUpload + "/" + sha1sum + "/" + fi.Name
 
-				path := dir + "/" + fi.Name
-				flog.Debugf("mediaserver path placing file: %s", path)
-
-				err = ioutil.WriteFile(path, *fi.Data, os.ModePerm)
-				if err != nil {
-					flog.Errorf("mediaserver path failed, could not writefile: %s %#v", err, err)
-					continue
-				}
+			req, err := http.NewRequest("PUT", url, bytes.NewReader(*fi.Data))
+			if err != nil {
+				flog.Errorf("mediaserver upload failed, could not create request: %#v", err)
+				continue
 			}
 
-			// We uploaded/placed the file successfully. Add the SHA and URL.
-			extra := msg.Extra["file"][i].(config.FileInfo)
-			extra.URL = durl
-			extra.SHA = sha1sum
-			msg.Extra["file"][i] = extra
+			flog.Debugf("mediaserver upload url: %s", url)
 
-			flog.Debugf("mediaserver download URL = %s", durl)
+			req.Header.Set("Content-Type", "binary/octet-stream")
+			_, err = client.Do(req)
+			if err != nil {
+				flog.Errorf("mediaserver upload failed, could not Do request: %#v", err)
+				continue
+			}
+		} else {
+			// Use MediaServerPath. Place the file on the current filesystem.
+
+			dir := gw.Config.General.MediaServerPath + "/" + sha1sum
+			err := os.Mkdir(dir, os.ModePerm)
+			if err != nil && !os.IsExist(err) {
+				flog.Errorf("mediaserver path failed, could not mkdir: %s %#v", err, err)
+				continue
+			}
+
+			path := dir + "/" + fi.Name
+			flog.Debugf("mediaserver path placing file: %s", path)
+
+			err = ioutil.WriteFile(path, *fi.Data, os.ModePerm)
+			if err != nil {
+				flog.Errorf("mediaserver path failed, could not writefile: %s %#v", err, err)
+				continue
+			}
 		}
+
+		// Download URL.
+		durl := gw.Config.General.MediaServerDownload + "/" + sha1sum + "/" + fi.Name
+
+		flog.Debugf("mediaserver download URL = %s", durl)
+
+		// We uploaded/placed the file successfully. Add the SHA and URL.
+		extra := msg.Extra["file"][i].(config.FileInfo)
+		extra.URL = durl
+		extra.SHA = sha1sum
+		msg.Extra["file"][i] = extra
 	}
 }
 

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -421,7 +421,7 @@ func (gw *Gateway) handleFiles(msg *config.Message) {
 	reg := regexp.MustCompile("[^a-zA-Z0-9]+")
 
 	// If we don't have a attachfield or we don't have a mediaserver configured return
-	if msg.Extra == nil || (gw.Config.General.MediaServerUpload == "" && gw.Config.General.MediaServerPath == "") {
+	if msg.Extra == nil || (gw.Config.General.MediaServerUpload == "" && gw.Config.General.MediaDownloadPath == "") {
 		return
 	}
 
@@ -465,7 +465,7 @@ func (gw *Gateway) handleFiles(msg *config.Message) {
 		} else {
 			// Use MediaServerPath. Place the file on the current filesystem.
 
-			dir := gw.Config.General.MediaServerPath + "/" + sha1sum
+			dir := gw.Config.General.MediaDownloadPath + "/" + sha1sum
 			err := os.Mkdir(dir, os.ModePerm)
 			if err != nil && !os.IsExist(err) {
 				flog.Errorf("mediaserver path failed, could not mkdir: %s %#v", err, err)

--- a/matterbridge.go
+++ b/matterbridge.go
@@ -3,13 +3,14 @@ package main
 import (
 	"flag"
 	"fmt"
+	"os"
+	"strings"
+
 	"github.com/42wim/matterbridge/bridge/config"
 	"github.com/42wim/matterbridge/gateway"
 	"github.com/google/gops/agent"
 	log "github.com/sirupsen/logrus"
 	prefixed "github.com/x-cray/logrus-prefixed-formatter"
-	"os"
-	"strings"
 )
 
 var (

--- a/matterbridge.toml.sample
+++ b/matterbridge.toml.sample
@@ -1305,16 +1305,20 @@ RemoteNickFormat="[{PROTOCOL}] <{NICK}> "
 StripNick=false
 
 
-#MediaServerUpload and MediaServerDownload are used for uploading images/files/video to
-#a remote "mediaserver" (a webserver like caddy for example).
+#MediaServerUpload (or MediaServerPath) and MediaServerDownload are used for uploading
+#images/files/video toa remote "mediaserver" (a webserver like caddy for example).
 #When configured images/files uploaded on bridges like mattermost,slack, telegram will be downloaded
 #and uploaded again to MediaServerUpload URL
+#MediaServerPath can be used instead of MediaServerUpload, for when your webserver is on the
+#same system as matterbridge and matterbridge has write access to the serve dir.
 #The MediaServerDownload will be used so that bridges without native uploading support:
 #gitter, irc and xmpp will be shown links to the files on MediaServerDownload
 #
 #More information https://github.com/42wim/matterbridge/wiki/Mediaserver-setup-%5Badvanced%5D
 #OPTIONAL (default empty)
 MediaServerUpload="https://user:pass@yourserver.com/upload"
+#OPTIONAL (default empty)
+MediaServerPath="/srv/http/yourserver.com/public/download"
 #OPTIONAL (default empty)
 MediaServerDownload="https://youserver.com/download"
 

--- a/matterbridge.toml.sample
+++ b/matterbridge.toml.sample
@@ -1305,12 +1305,13 @@ RemoteNickFormat="[{PROTOCOL}] <{NICK}> "
 StripNick=false
 
 
-#MediaServerUpload (or MediaServerPath) and MediaServerDownload are used for uploading
-#images/files/video toa remote "mediaserver" (a webserver like caddy for example).
-#When configured images/files uploaded on bridges like mattermost,slack, telegram will be downloaded
-#and uploaded again to MediaServerUpload URL
-#MediaServerPath can be used instead of MediaServerUpload, for when your webserver is on the
-#same system as matterbridge and matterbridge has write access to the serve dir.
+#MediaServerUpload (or MediaDownloadPath) and MediaServerDownload are used for uploading
+#images/files/video to a remote "mediaserver" (a webserver like caddy for example).
+#When configured images/files uploaded on bridges like mattermost, slack, telegram will be
+#downloaded and uploaded again to MediaServerUpload URL
+#MediaDownloadPath is the filesystem path where the media file will be placed, instead of uploaded,
+#for if Matterbridge has write access to the directory your webserver is serving.
+#It is an alternative to MediaServerUpload.
 #The MediaServerDownload will be used so that bridges without native uploading support:
 #gitter, irc and xmpp will be shown links to the files on MediaServerDownload
 #
@@ -1318,7 +1319,7 @@ StripNick=false
 #OPTIONAL (default empty)
 MediaServerUpload="https://user:pass@yourserver.com/upload"
 #OPTIONAL (default empty)
-MediaServerPath="/srv/http/yourserver.com/public/download"
+MediaDownloadPath="/srv/http/yourserver.com/public/download"
 #OPTIONAL (default empty)
 MediaServerDownload="https://youserver.com/download"
 


### PR DESCRIPTION
Add option MediaServerPath.
Can be used instead of MediaServerUpload for when your webserver is on the same system as matterbridge and matterbridge has write access to the serve dir.

Instead of uploading (like MediaServerUpload does), MediaServerPath will download it to a location on the current system.

I made this since running a caddy server (or configuring my current nginx installation for uploading) seems kind of overkill for me, when I could just give my matterbridge write access to the /srv/http directory.