### PR TITLE
Add Title from attachment slack message

### DIFF
--- a/bridge/slack/slack.go
+++ b/bridge/slack/slack.go
@@ -503,7 +503,10 @@ func (b *Bslack) handleMessageEvent(ev *slack.MessageEvent) (*config.Message, er
 	if rmsg.Text == "" {
 		for _, attach := range ev.Attachments {
 			if attach.Text != "" {
-				rmsg.Text = attach.Text
+				if attach.Title != "" {
+					rmsg.Text = attach.Title + "\n"
+				}
+				rmsg.Text += attach.Text
 			} else {
 				rmsg.Text = attach.Fallback
 			}


### PR DESCRIPTION
Current behavior: Some monitoring systems use Title (like prometheus alertmanager) and this text lost
After this fix: Title text will be added to the message