### PR TITLE
Readme - link fix and minor clarification added. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,9 @@ See https://github.com/42wim/matterbridge/wiki
 * Development releases (follows master) can be downloaded [here](https://dl.bintray.com/42wim/nightly/)  
 
 ## Building
-Go 1.8+ is required. Make sure you have [Go](https://golang.org/doc/install) properly installed, including setting up your [GOPATH] (https://golang.org/doc/code.html#GOPATH)
+Go 1.8+ is required. Make sure you have [Go](https://golang.org/doc/install) properly installed, including setting up your [GOPATH](https://golang.org/doc/code.html#GOPATH).
+
+After Go is setup, download matterbridge to your $GOPATH directory. 
 
 ```
 cd $GOPATH


### PR DESCRIPTION
Fixed typo in the GOPATH link.
While there, I added a sentence of clarification to make it clear that first code block in that section is about installing matterbridge and not related to setting up Go. Having no prior experience with Go, I was a bit confused when I go to the Building section. I believe the new line adds minor but useful clarification.