### PR TITLE
Stop numbers being stripped after non-color control codes

### DIFF
--- a/bridge/irc/irc.go
+++ b/bridge/irc/irc.go
@@ -397,7 +397,7 @@ func (b *Birc) handlePrivMsg(client *girc.Client, event girc.Event) {
 	rmsg.Text += event.StripAction()
 
 	// strip IRC colors
-	re := regexp.MustCompile(`[[:cntrl:]](?:\d{1,2}(?:,\d{1,2})?)?`)
+	re := regexp.MustCompile(`\x03(?:\d{1,2}(?:,\d{1,2})?)?|[[:cntrl:]]`)
 	rmsg.Text = re.ReplaceAllString(rmsg.Text, "")
 
 	// start detecting the charset


### PR DESCRIPTION
Currently numbers are stripped not just after the color control code (\x03) but also after other formatting such as bold (\x02) and italic (\x1D), which is both unnecessary and leads to missing text from irc. This fixes that by only stripping numbers after the color control code.