### PR TITLE
Slack bridge no longer POSTing username and avatar

### DIFF
--- a/bridge/slack/helpers.go
+++ b/bridge/slack/helpers.go
@@ -65,8 +65,11 @@ func (b *Bslack) populateUsers() {
 	}
 
 	newUsers := map[string]*slack.User{}
-	for _, user := range users {
-		newUsers[user.ID] = &user
+	for i, _ := range users {
+		// Use array index for pointer, not the copy
+		// See: https://stackoverflow.com/a/29498133/504018
+		u := &users[i]
+		newUsers[u.ID] = u
 	}
 
 	b.usersMutex.Lock()

--- a/bridge/slack/helpers.go
+++ b/bridge/slack/helpers.go
@@ -68,8 +68,7 @@ func (b *Bslack) populateUsers() {
 	for i, _ := range users {
 		// Use array index for pointer, not the copy
 		// See: https://stackoverflow.com/a/29498133/504018
-		u := &users[i]
-		newUsers[u.ID] = u
+    newUsers[users[i].ID] = &users[i]
 	}
 
 	b.usersMutex.Lock()

--- a/bridge/slack/helpers.go
+++ b/bridge/slack/helpers.go
@@ -68,7 +68,7 @@ func (b *Bslack) populateUsers() {
 	for i := range users {
 		// Use array index for pointer, not the copy
 		// See: https://stackoverflow.com/a/29498133/504018
-    newUsers[users[i].ID] = &users[i]
+		newUsers[users[i].ID] = &users[i]
 	}
 
 	b.usersMutex.Lock()

--- a/bridge/slack/helpers.go
+++ b/bridge/slack/helpers.go
@@ -65,7 +65,7 @@ func (b *Bslack) populateUsers() {
 	}
 
 	newUsers := map[string]*slack.User{}
-	for i, _ := range users {
+	for i := range users {
 		// Use array index for pointer, not the copy
 		// See: https://stackoverflow.com/a/29498133/504018
     newUsers[users[i].ID] = &users[i]


### PR DESCRIPTION
**Describe the bug**
~Username~ avatar no longer used (ignore the CHANNEL token as unrelated)

![screen shot 2018-10-23 at 6 02 59 pm](https://user-images.githubusercontent.com/305339/47353069-e9a07380-d6ed-11e8-939e-61ffe9372437.png)


**To Reproduce**
Use current master for a slack-to-slack bridge on same slack team.

**Expected behavior**
Expect ~username~ avatar to be POSTed.

~I think I know how to fix this. nlopes is getting refactored, and I hit the same thing earlier.~

~I think this is related to go.mod -- I'm assuming @Helcaraxan was using 4.1-dev, and this was merged into mainline that is using 4.0 still.~

~Should we update to an untagged commit on `nlopes/slack` or revert your changes to the message POST method, @Helcaraxan?~

Apologies, I am tired. This seems to be new. Will investigate.