### PR TITLE
Add editorconfig support

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,2 @@
+[*.go]
+indent_style=tab


### PR DESCRIPTION
Just makes it so that IDEs automatically use the right indentation.

https://editorconfig.org/