### PR TITLE
Opportunistically preserve threading between Slack instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Minecraft server chat support via [MatterLink](https://github.com/elytra/MatterL
 * [Support bridging between any protocols](https://github.com/42wim/matterbridge/wiki/Features#support-bridging-between-any-protocols)
 * [Support multiple gateways(bridges) for your protocols](https://github.com/42wim/matterbridge/wiki/Features#support-multiple-gatewaysbridges-for-your-protocols)
 * [Message edits and deletes](https://github.com/42wim/matterbridge/wiki/Features#message-edits-and-deletes)
+* Preserves threading when possible
 * [Attachment / files handling](https://github.com/42wim/matterbridge/wiki/Features#attachment--files-handling)
 * [Username and avatar spoofing](https://github.com/42wim/matterbridge/wiki/Features#username-and-avatar-spoofing)
 * [Private groups](https://github.com/42wim/matterbridge/wiki/Features#private-groups)

--- a/bridge/config/config.go
+++ b/bridge/config/config.go
@@ -35,6 +35,7 @@ type Message struct {
 	Event     string    `json:"event"`
 	Protocol  string    `json:"protocol"`
 	Gateway   string    `json:"gateway"`
+	ThreadTs  string    `json:"thread_timestamp"`
 	Timestamp time.Time `json:"timestamp"`
 	ID        string    `json:"id"`
 	Extra     map[string][]interface{}

--- a/bridge/config/config.go
+++ b/bridge/config/config.go
@@ -99,6 +99,7 @@ type Protocol struct {
 	NoTLS                  bool       // mattermost
 	Password               string     // IRC,mattermost,XMPP,matrix
 	PrefixMessagesWithNick bool       // mattemost, slack
+	PreserveThreading      bool       // slack
 	Protocol               string     // all protocols
 	QuoteDisable           bool       // telegram
 	QuoteFormat            string     // telegram

--- a/bridge/config/config.go
+++ b/bridge/config/config.go
@@ -35,7 +35,7 @@ type Message struct {
 	Event     string    `json:"event"`
 	Protocol  string    `json:"protocol"`
 	Gateway   string    `json:"gateway"`
-	ThreadTs  string    `json:"thread_timestamp"`
+	ParentID  string    `json:"parent_id"`
 	Timestamp time.Time `json:"timestamp"`
 	ID        string    `json:"id"`
 	Extra     map[string][]interface{}

--- a/bridge/slack/handlers.go
+++ b/bridge/slack/handlers.go
@@ -171,7 +171,7 @@ func (b *Bslack) handleMessageEvent(ev *slack.MessageEvent) (*config.Message, er
 		Account: b.Account,
 		ID:      "slack " + ev.Timestamp,
 		Extra:   map[string][]interface{}{},
-		ThreadTs: ev.ThreadTimestamp,
+		ParentID: ev.ThreadTimestamp,
 	}
 
 

--- a/bridge/slack/handlers.go
+++ b/bridge/slack/handlers.go
@@ -171,7 +171,9 @@ func (b *Bslack) handleMessageEvent(ev *slack.MessageEvent) (*config.Message, er
 		Account: b.Account,
 		ID:      "slack " + ev.Timestamp,
 		Extra:   map[string][]interface{}{},
+		ThreadTs: ev.ThreadTimestamp,
 	}
+
 
 	if b.useChannelID {
 		rmsg.Channel = "ID:" + channelInfo.ID

--- a/bridge/slack/slack.go
+++ b/bridge/slack/slack.go
@@ -310,7 +310,7 @@ func (b *Bslack) prepareMessageParameters(msg *config.Message) *slack.PostMessag
 	params.Username = msg.Username
 	params.LinkNames = 1 // replace mentions
 	params.IconURL = config.GetIconURL(msg, b.GetString(iconURLConfig))
-	params.ThreadTimestamp = msg.ThreadTs
+	params.ThreadTimestamp = msg.ParentID
 	if msg.Avatar != "" {
 		params.IconURL = msg.Avatar
 	}

--- a/bridge/slack/slack.go
+++ b/bridge/slack/slack.go
@@ -310,6 +310,7 @@ func (b *Bslack) prepareMessageParameters(msg *config.Message) *slack.PostMessag
 	params.Username = msg.Username
 	params.LinkNames = 1 // replace mentions
 	params.IconURL = config.GetIconURL(msg, b.GetString(iconURLConfig))
+	params.ThreadTimestamp = msg.ThreadTs
 	if msg.Avatar != "" {
 		params.IconURL = msg.Avatar
 	}

--- a/bridge/slack/slack.go
+++ b/bridge/slack/slack.go
@@ -312,10 +312,7 @@ func (b *Bslack) prepareMessageParameters(msg *config.Message) *slack.PostMessag
 	params.IconURL = config.GetIconURL(msg, b.GetString(iconURLConfig))
 	msgFields := strings.Fields(msg.ParentID)
 	if len(msgFields) >= 2 {
-		msgProtocol, msgID := msgFields[0], msgFields[1]
-		if msgProtocol == "slack" {
-			params.ThreadTimestamp = msgID
-		}
+		params.ThreadTimestamp = msgFields[1]
 	}
 	if msg.Avatar != "" {
 		params.IconURL = msg.Avatar

--- a/bridge/slack/slack.go
+++ b/bridge/slack/slack.go
@@ -310,7 +310,13 @@ func (b *Bslack) prepareMessageParameters(msg *config.Message) *slack.PostMessag
 	params.Username = msg.Username
 	params.LinkNames = 1 // replace mentions
 	params.IconURL = config.GetIconURL(msg, b.GetString(iconURLConfig))
-	params.ThreadTimestamp = msg.ParentID
+	msgFields := strings.Fields(msg.ParentID)
+	if len(msgFields) >= 2 {
+		msgProtocol, msgID := msgFields[0], msgFields[1]
+		if msgProtocol == "slack" {
+			params.ThreadTimestamp = msgID
+		}
+	}
 	if msg.Avatar != "" {
 		params.IconURL = msg.Avatar
 	}

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -312,11 +312,9 @@ func (gw *Gateway) handleMessage(msg config.Message, dest *bridge.Bridge) []*BrM
 			msg.Channel = originchannel
 		}
 
-		if canonicalParentMsgID != "" {
-			msg.ParentID =  gw.getDestMsgID(canonicalParentMsgID, dest, channel)
-			if msg.ParentID == "" {
-			   msg.ParentID = canonicalParentMsgID
-			}
+		msg.ParentID =  gw.getDestMsgID(canonicalParentMsgID, dest, channel)
+		if msg.ParentID == "" {
+		   msg.ParentID = canonicalParentMsgID
 		}
 
 		mID, err := dest.Send(msg)

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -303,7 +303,7 @@ func (gw *Gateway) handleMessage(msg config.Message, dest *bridge.Bridge) []*BrM
 		msg.Avatar = gw.modifyAvatar(origmsg, dest)
 		msg.Username = gw.modifyUsername(origmsg, dest)
 		msg.ID = ""
-		msg.ParentID = ""
+		msg.ParentID = gw.getDestMsgID(canonicalParentMsgID, dest, channel)
 
 		msg.ID = gw.getDestMsgID(origmsg.ID, dest, channel)
 

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -83,6 +83,26 @@ func New(cfg config.Gateway, r *Router) *Gateway {
 	return gw
 }
 
+// Find the timestamp that the message is keyed under in cache
+func (gw *Gateway) FindUpstreamTimestamp(timestamp string) string {
+	if gw.Messages.Contains("slack "+timestamp) {
+		return timestamp
+	}
+
+	for _, k := range gw.Messages.Keys() {
+		upstreamMsgID := k.(string)
+		v, _ := gw.Messages.Peek(k)
+		ids := v.([]*BrMsgID)
+		for _, downstreamMsgObj := range ids {
+			downstreamTimestamp := strings.Fields(downstreamMsgObj.ID)[1]
+			if downstreamTimestamp == timestamp {
+				return strings.Fields(upstreamMsgID)[1]
+			}
+		}
+	}
+	return ""
+}
+
 func (gw *Gateway) AddBridge(cfg *config.Bridge) error {
 	br := gw.Router.getBridge(cfg.Account)
 	if br == nil {
@@ -242,6 +262,12 @@ func (gw *Gateway) handleMessage(msg config.Message, dest *bridge.Bridge) []*BrM
 		return brMsgIDs
 	}
 
+	// Get the upstreamTimestamp of the thread_ts
+	var upstreamTimestamp string
+	if msg.ThreadTs != "" {
+		upstreamTimestamp = gw.FindUpstreamTimestamp(msg.ThreadTs)
+	}
+
 	originchannel := msg.Channel
 	origmsg := msg
 	channels := gw.getDestChannel(&msg, *dest)
@@ -262,6 +288,7 @@ func (gw *Gateway) handleMessage(msg config.Message, dest *bridge.Bridge) []*BrM
 		msg.Avatar = gw.modifyAvatar(origmsg, dest)
 		msg.Username = gw.modifyUsername(origmsg, dest)
 		msg.ID = ""
+		msg.ThreadTs = ""
 		if res, ok := gw.Messages.Get(origmsg.ID); ok {
 			IDs := res.([]*BrMsgID)
 			for _, id := range IDs {
@@ -276,10 +303,26 @@ func (gw *Gateway) handleMessage(msg config.Message, dest *bridge.Bridge) []*BrM
 		if dest.Protocol == "api" {
 			msg.Channel = originchannel
 		}
+
+		if upstreamTimestamp != "" {
+			if res, ok := gw.Messages.Get("slack "+upstreamTimestamp); ok {
+				IDs := res.([]*BrMsgID)
+				for _, id := range IDs {
+					// check protocol, bridge name and channelname
+					// for people that reuse the same bridge multiple times. see #342
+					if dest.Protocol == id.br.Protocol && dest.Name == id.br.Name && channel.ID == id.ChannelID {
+						msg.ThreadTs = strings.Fields(id.ID)[1]
+					}
+				}
+				if msg.ThreadTs == "" { msg.ThreadTs = upstreamTimestamp }
+			}
+		}
+
 		mID, err := dest.Send(msg)
 		if err != nil {
 			flog.Error(err)
 		}
+
 		// append the message ID (mID) from this bridge (dest) to our brMsgIDs slice
 		if mID != "" {
 			flog.Debugf("mID %s: %s", dest.Account, mID)

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -302,8 +302,6 @@ func (gw *Gateway) handleMessage(msg config.Message, dest *bridge.Bridge) []*BrM
 		msg.Channel = channel.Name
 		msg.Avatar = gw.modifyAvatar(origmsg, dest)
 		msg.Username = gw.modifyUsername(origmsg, dest)
-		msg.ID = ""
-		msg.ParentID = gw.getDestMsgID(canonicalParentMsgID, dest, channel)
 
 		msg.ID = gw.getDestMsgID(origmsg.ID, dest, channel)
 

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -263,7 +263,7 @@ func (gw *Gateway) handleMessage(msg config.Message, dest *bridge.Bridge) []*BrM
 
 	// Get the ID of the parent message in thread
 	var canonicalParentMsgID string
-	if msg.ParentID != "" {
+	if msg.ParentID != "" && (gw.Config.General.PreserveThreading || dest.GetBool("PreserveThreading")) {
 		thisParentMsgID := dest.Protocol + " " + msg.ParentID
 		canonicalParentMsgID = gw.FindCanonicalMsgID(thisParentMsgID)
 	}

--- a/matterbridge.toml.sample
+++ b/matterbridge.toml.sample
@@ -659,6 +659,12 @@ StripNick=false
 #OPTIONAL (default false)
 ShowTopicChange=false
 
+#Opportunistically preserve threaded replies between Slack channels.
+#This only works if the parent message is still in the cache.
+#Cache is flushed between restarts.
+#OPTIONAL (default false)
+PreserveThreading=false
+
 ###################################################################
 #discord section
 ###################################################################


### PR DESCRIPTION
**Is your feature request related to a problem? Please describe.**
Even with clear documentation and encouragement of work-arounds, unthreading of messages between slacks leads to confusion and misunderstanding.

**Describe the solution you'd like**
Would be great to preserve threading between Slack instances, when possible. Presumably this would be when the parent message is still in cache.

**Describe alternatives you've considered**
- Clear documentation
- https://github.com/42wim/matterbridge/issues/343

**Additional context**
Downside: There would be inconsistency: sometimes a channel-level message would have originated as a channel-level message, but sometimes it would be a thread-level message where there wasn't enough detail in cache to rethread. And the oldest replies (not in cache) would be the most common to unthread, which are the ones most likely to cause confusion anyhow,