### PR TITLE
When auto-loading envvars from viper config, remove hyphens

### DIFF
--- a/bridge/config/config.go
+++ b/bridge/config/config.go
@@ -185,7 +185,7 @@ func NewConfig(cfgfile string) *Config {
 	viper.SetConfigFile(cfgfile)
 	viper.SetEnvPrefix("matterbridge")
 	viper.AddConfigPath(".")
-	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
+	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_", "-", ""))
 	viper.AutomaticEnv()
 	f, err := os.Open(cfgfile)
 	if err != nil {

--- a/bridge/config/config.go
+++ b/bridge/config/config.go
@@ -185,7 +185,7 @@ func NewConfig(cfgfile string) *Config {
 	viper.SetConfigFile(cfgfile)
 	viper.SetEnvPrefix("matterbridge")
 	viper.AddConfigPath(".")
-	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_", "-", ""))
+	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_", "-", "_"))
 	viper.AutomaticEnv()
 	f, err := os.Open(cfgfile)
 	if err != nil {


### PR DESCRIPTION
See: https://unix.stackexchange.com/questions/23659/can-shell-variable-include-character