### PR TITLE
Crash with divide by zero error if message sent before API endpoint viewed

### DIFF
--- a/bridge/api/api.go
+++ b/bridge/api/api.go
@@ -33,7 +33,9 @@ func New(cfg *bridge.Config) bridge.Bridger {
 	e.HideBanner = true
 	e.HidePort = true
 	b.Messages = ring.Ring{}
-	b.Messages.SetCapacity(b.GetInt("Buffer"))
+	if b.GetInt("Buffer") != 0 {
+		b.Messages.SetCapacity(b.GetInt("Buffer"))
+	}
 	if b.GetString("Token") != "" {
 		e.Use(middleware.KeyAuth(func(key string, c echo.Context) (bool, error) {
 			return key == b.GetString("Token"), nil

--- a/matterbridge.toml.sample
+++ b/matterbridge.toml.sample
@@ -1214,6 +1214,7 @@ ShowTopicChange=false
 BindAddress="127.0.0.1:4242"
 
 #Amount of messages to keep in memory
+#OPTIONAL (library default 10)
 Buffer=1000
 
 #Bearer token used for authentication


### PR DESCRIPTION
**Describe the bug**
Trying to send a message before first hitting endpoint (example: /api/messages) results in bridge crashing

**To Reproduce**
set bind address and start a slack gateway with two bridges. Send a message and watch logs. Matterbridge should crash. Repeat, but visit /api/messages first (empty array). Matterbridge should stay up.

**Expected behavior**
Not crashing.

**Screenshots/debug logs**
```
[0002]  INFO main:         Gateway(s) started succesfully. Now relaying messages
panic: runtime error: integer divide by zero

goroutine 50 [running]:
github.com/zfjagann/golang-ring.(*Ring).mod(...)
	/Users/patcon/go/pkg/mod/github.com/zfjagann/golang-ring@v0.0.0-20141111230621-17637388c9f6/ring.go:120
github.com/zfjagann/golang-ring.(*Ring).set(...)
	/Users/patcon/go/pkg/mod/github.com/zfjagann/golang-ring@v0.0.0-20141111230621-17637388c9f6/ring.go:110
github.com/zfjagann/golang-ring.(*Ring).Enqueue(0xc0003cd9f0, 0x18b4f20, 0xc000dc83c0)
	/Users/patcon/go/pkg/mod/github.com/zfjagann/golang-ring@v0.0.0-20141111230621-17637388c9f6/ring.go:43 +0x121
github.com/42wim/matterbridge/bridge/api.(*Api).Send(0xc0003cd9f0, 0xc0009199b0, 0x5, 0xc0003d5580, 0xf, 0x0, 0x0, 0xc000919860, 0x9, 0xc000b6adc0, ...)
	/Users/patcon/repos/matterbridge/bridge/api/api.go:74 +0xfc
github.com/42wim/matterbridge/gateway.(*Gateway).handleMessage(0xc0003cd860, 0xc0009199b0, 0x5, 0xc0003d5580, 0xf, 0x0, 0x0, 0xc000919860, 0x9, 0xc000b6adc0, ...)
	/Users/patcon/repos/matterbridge/gateway/gateway.go:279 +0x46b
github.com/42wim/matterbridge/gateway.(*Router).handleReceive(0xc0003df780)
	/Users/patcon/repos/matterbridge/gateway/router.go:102 +0x2b1
created by github.com/42wim/matterbridge/gateway.(*Router).Start
	/Users/patcon/repos/matterbridge/gateway/router.go:58 +0x570
exit status 2
```

**Environment (please complete the following information):**
 - OS: osx
 - Matterbridge version: 3b8837a16bdfca5085f37867d08571a03a66f8e9