### PR TITLE
Add ability to show when user is typing across Slack bridges

### DIFF
--- a/bridge/config/config.go
+++ b/bridge/config/config.go
@@ -23,6 +23,7 @@ const (
 	EVENT_USER_ACTION       = "user_action"
 	EVENT_MSG_DELETE        = "msg_delete"
 	EVENT_API_CONNECTED     = "api_connected"
+	EVENT_USER_TYPING       = "user_typing"
 )
 
 type Message struct {
@@ -110,6 +111,7 @@ type Protocol struct {
 	Server                 string     // IRC,mattermost,XMPP,discord
 	ShowJoinPart           bool       // all protocols
 	ShowTopicChange        bool       // slack
+	ShowUserTyping         bool       // slack
 	ShowEmbeds             bool       // discord
 	SkipTLSVerify          bool       // IRC, mattermost
 	StripNick              bool       // all protocols

--- a/bridge/slack/handlers.go
+++ b/bridge/slack/handlers.go
@@ -23,7 +23,9 @@ func (b *Bslack) handleSlack() {
 	time.Sleep(time.Second)
 	b.Log.Debug("Start listening for Slack messages")
 	for message := range messages {
-		b.Log.Debugf("<= Sending message from %s on %s to gateway", message.Username, b.Account)
+		if message.Event != config.EVENT_USER_TYPING {
+			b.Log.Debugf("<= Sending message from %s on %s to gateway", message.Username, b.Account)
+		}
 
 		// cleanup the message
 		message.Text = b.replaceMention(message.Text)

--- a/bridge/slack/handlers.go
+++ b/bridge/slack/handlers.go
@@ -256,8 +256,6 @@ func (b *Bslack) handleTypingEvent(ev *slack.UserTypingEvent) (*config.Message, 
 		Channel:  channelInfo.Name,
 		Account:  b.Account,
 		Event:    config.EVENT_USER_TYPING,
-		ID:       "slack " + time.Now().String(),
-		Extra:    map[string][]interface{}{},
 	}
 
 	return &rmsg, nil

--- a/bridge/slack/handlers.go
+++ b/bridge/slack/handlers.go
@@ -254,10 +254,9 @@ func (b *Bslack) handleTypingEvent(ev *slack.UserTypingEvent) (*config.Message, 
 	}
 
 	rmsg := config.Message{
-		Username: b.getUsername(ev.User),
-		Channel:  channelInfo.Name,
-		Account:  b.Account,
-		Event:    config.EVENT_USER_TYPING,
+		Channel: channelInfo.Name,
+		Account: b.Account,
+		Event:   config.EVENT_USER_TYPING,
 	}
 
 	return &rmsg, nil

--- a/bridge/slack/handlers.go
+++ b/bridge/slack/handlers.go
@@ -46,6 +46,14 @@ func (b *Bslack) handleSlackClient(messages chan *config.Message) {
 			b.Log.Debugf("== Receiving event %#v", msg.Data)
 		}
 		switch ev := msg.Data.(type) {
+		case *slack.UserTypingEvent:
+			rmsg, err := b.handleTypingEvent(ev)
+			if err != nil {
+				b.Log.Errorf("%#v", err)
+				continue
+			}
+
+			messages <- rmsg
 		case *slack.MessageEvent:
 			if b.skipMessageEvent(ev) {
 				b.Log.Debugf("Skipped message: %#v", ev)
@@ -234,6 +242,27 @@ func (b *Bslack) handleAttachments(ev *slack.MessageEvent, rmsg *config.Message)
 }
 
 var commentRE = regexp.MustCompile(`.*?commented: (.*)`)
+
+func (b *Bslack) handleTypingEvent(ev *slack.UserTypingEvent) (*config.Message, error) {
+	var err error
+	// use our own func because rtm.GetChannelInfo doesn't work for private channels
+	channelInfo, err := b.getChannelByID(ev.Channel)
+	if err != nil {
+		return nil, err
+	}
+
+	rmsg := config.Message{
+		Username: b.getUsername(ev.User),
+		Channel:  channelInfo.Name,
+		Account:  b.Account,
+		Event:    config.EVENT_USER_TYPING,
+		ID:       "slack " + time.Now().String(),
+		Extra:    map[string][]interface{}{},
+	}
+
+	return &rmsg, nil
+
+}
 
 // handleDownloadFile handles file download
 func (b *Bslack) handleDownloadFile(rmsg *config.Message, file *slack.File) error {

--- a/bridge/slack/slack.go
+++ b/bridge/slack/slack.go
@@ -265,16 +265,15 @@ func (b *Bslack) sendWebhook(msg config.Message) (string, error) {
 }
 
 func (b *Bslack) sendRTM(msg config.Message) (string, error) {
-	if msg.Event == config.EVENT_USER_TYPING && b.GetBool("ShowUserTyping") {
-		if b.GetBool("ShowUserTyping") {
-			chanID := b.channelsByName[msg.Channel].ID
-			b.rtm.SendMessage(b.rtm.NewTypingMessage(chanID))
-		}
-		return "", nil
-	}
 	channelInfo, err := b.getChannel(msg.Channel)
 	if err != nil {
 		return "", fmt.Errorf("could not send message: %v", err)
+	}
+	if msg.Event == config.EVENT_USER_TYPING {
+		if b.GetBool("ShowUserTyping") {
+			b.rtm.SendMessage(b.rtm.NewTypingMessage(channelInfo.ID))
+		}
+		return "", nil
 	}
 
 	// Delete message

--- a/bridge/slack/slack.go
+++ b/bridge/slack/slack.go
@@ -265,7 +265,7 @@ func (b *Bslack) sendWebhook(msg config.Message) (string, error) {
 }
 
 func (b *Bslack) sendRTM(msg config.Message) (string, error) {
-	if msg.Event == config.EVENT_USER_TYPING {
+	if msg.Event == config.EVENT_USER_TYPING && b.GetBool("ShowUserTyping") {
 		if b.GetBool("ShowUserTyping") {
 			chanID := b.channelsByName[msg.Channel].ID
 			b.rtm.SendMessage(b.rtm.NewTypingMessage(chanID))

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -297,7 +297,11 @@ func (gw *Gateway) handleMessage(msg config.Message, dest *bridge.Bridge) []*BrM
 				continue
 			}
 		}
-		flog.Debugf("=> Sending %#v from %s (%s) to %s (%s)", msg, msg.Account, originchannel, dest.Account, channel.Name)
+
+		// Too noisy to log like other events
+		if msg.Event != config.EVENT_USER_TYPING {
+			flog.Debugf("=> Sending %#v from %s (%s) to %s (%s)", msg, msg.Account, originchannel, dest.Account, channel.Name)
+		}
 
 		msg.Channel = channel.Name
 		msg.Avatar = gw.modifyAvatar(origmsg, dest)
@@ -337,6 +341,9 @@ func (gw *Gateway) ignoreMessage(msg *config.Message) bool {
 
 	// check if we need to ignore a empty message
 	if msg.Text == "" {
+		if msg.Event == config.EVENT_USER_TYPING {
+			return false
+		}
 		// we have an attachment or actual bytes, do not ignore
 		if msg.Extra != nil &&
 			(msg.Extra["attachments"] != nil ||

--- a/matterbridge.toml.sample
+++ b/matterbridge.toml.sample
@@ -665,6 +665,12 @@ ShowTopicChange=false
 #OPTIONAL (default false)
 PreserveThreading=false
 
+#Enable showing "user_typing" events from across gateway when available.
+#Hint: Set your bot/user's "Full Name" to be "Someone",
+#and so the message will say "Someone is typing".
+#OPTIONAL (default true)
+ShowUserTyping=true
+
 ###################################################################
 #discord section
 ###################################################################

--- a/matterbridge.toml.sample
+++ b/matterbridge.toml.sample
@@ -668,8 +668,8 @@ PreserveThreading=false
 #Enable showing "user_typing" events from across gateway when available.
 #Hint: Set your bot/user's "Full Name" to be "Someone",
 #and so the message will say "Someone is typing".
-#OPTIONAL (default true)
-ShowUserTyping=true
+#OPTIONAL (default false)
+ShowUserTyping=false
 
 ###################################################################
 #discord section


### PR DESCRIPTION
Addresses \#516

Should be possible to get this working for Mattermost as well, just not sure how, so leaving it for another PR.

If your "Real Name" of your bot/user is set appropriately, the typing message even sounds semantic :)

![screen shot 2018-11-06 at 11 58 42 pm](https://user-images.githubusercontent.com/305339/48076394-0d9ca280-e220-11e8-9c5e-bbbb33dd2a8c.png)
