### PR TITLE
Allow simple remote configuration files

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Minecraft server chat support via [MatterLink](https://github.com/elytra/MatterL
 * [Support multiple gateways(bridges) for your protocols](https://github.com/42wim/matterbridge/wiki/Features#support-multiple-gatewaysbridges-for-your-protocols)
 * [Message edits and deletes](https://github.com/42wim/matterbridge/wiki/Features#message-edits-and-deletes)
 * Preserves threading when possible
+* Remote configuration files
 * [Attachment / files handling](https://github.com/42wim/matterbridge/wiki/Features#attachment--files-handling)
 * [Username and avatar spoofing](https://github.com/42wim/matterbridge/wiki/Features#username-and-avatar-spoofing)
 * [Private groups](https://github.com/42wim/matterbridge/wiki/Features#private-groups)

--- a/bridge/api/api.go
+++ b/bridge/api/api.go
@@ -100,11 +100,11 @@ func (b *Api) handleConfigReload(c echo.Context) error {
 		return c.String(http.StatusInternalServerError, "Internal Server Error")
 	}
 	res, err := http.Get(cfgURL)
-	defer res.Body.Close()
 	if err != nil {
 		b.Log.Error("Failed to fetch remote config file: ", err)
 		return c.String(http.StatusInternalServerError, "Internal Server Error")
 	}
+	defer res.Body.Close()
 	content, err := ioutil.ReadAll(res.Body)
 	if err != nil {
 		b.Log.Error("Error reading remote config file: ", err)

--- a/bridge/api/api.go
+++ b/bridge/api/api.go
@@ -110,7 +110,7 @@ func (b *Api) handleConfigReload(c echo.Context) error {
 		b.Log.Error("Error reading remote config file: ", err)
 		return c.String(http.StatusInternalServerError, "Internal Server Error")
 	}
-	cfgfile := b.ConfigFileUsed()
+	cfgfile := b.Config.ConfigFileUsed()
 	err = ioutil.WriteFile(cfgfile, content, 0644)
 	if err != nil {
 		b.Log.Error("Failed to write remote config file: ", err)

--- a/bridge/api/api.go
+++ b/bridge/api/api.go
@@ -110,7 +110,7 @@ func (b *Api) handleConfigReload(c echo.Context) error {
 		b.Log.Error("Error reading remote config file: ", err)
 		return c.String(http.StatusInternalServerError, "Internal Server Error")
 	}
-	cfgfile := b.Config.ConfigFileUsed()
+	cfgfile := b.Config.Bridge.Config.ConfigFileUsed()
 	err = ioutil.WriteFile(cfgfile, content, 0644)
 	if err != nil {
 		b.Log.Error("Failed to write remote config file: ", err)

--- a/bridge/api/api.go
+++ b/bridge/api/api.go
@@ -110,7 +110,7 @@ func (b *Api) handleConfigReload(c echo.Context) error {
 		b.Log.Error("Error reading remote config file: ", err)
 		return c.String(http.StatusInternalServerError, "Internal Server Error")
 	}
-	cfgfile := b.GetConfigFile()
+	cfgfile := b.ConfigFileUsed()
 	err = ioutil.WriteFile(cfgfile, content, 0644)
 	if err != nil {
 		b.Log.Error("Failed to write remote config file: ", err)

--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -68,6 +68,10 @@ func (b *Bridge) joinChannels(channels map[string]config.ChannelInfo, exists map
 	return nil
 }
 
+func (b *Bridge) GetConfigFile() string {
+	return b.Config.GetConfigFile()
+}
+
 func (b *Bridge) GetBool(key string) bool {
 	if b.Config.GetBool(b.Account + "." + key) {
 		return b.Config.GetBool(b.Account + "." + key)

--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -68,10 +68,6 @@ func (b *Bridge) joinChannels(channels map[string]config.ChannelInfo, exists map
 	return nil
 }
 
-func (b *Bridge) ConfigFileUsed() string {
-	return b.Config.ConfigFileUsed()
-}
-
 func (b *Bridge) GetBool(key string) bool {
 	if b.Config.GetBool(b.Account + "." + key) {
 		return b.Config.GetBool(b.Account + "." + key)

--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -68,8 +68,8 @@ func (b *Bridge) joinChannels(channels map[string]config.ChannelInfo, exists map
 	return nil
 }
 
-func (b *Bridge) GetConfigFile() string {
-	return b.Config.GetConfigFile()
+func (b *Bridge) ConfigFileUsed() string {
+	return b.Config.ConfigFileUsed()
 }
 
 func (b *Bridge) GetBool(key string) bool {

--- a/bridge/config/config.go
+++ b/bridge/config/config.go
@@ -200,7 +200,7 @@ func NewConfig(cfgfile string) *Config {
 	})
 
 	mycfg.v.Set("ConfigFile", cfgfile)
-	mycfg.ConfigValues = &cfg
+
 	return mycfg
 }
 

--- a/bridge/config/config.go
+++ b/bridge/config/config.go
@@ -173,7 +173,6 @@ type ConfigValues struct {
 	General            Protocol
 	Gateway            []Gateway
 	SameChannelGateway []SameChannelGateway
-	ConfigFile         string
 }
 
 type Config struct {
@@ -234,8 +233,8 @@ func NewConfigFromString(input []byte) *Config {
 	return mycfg
 }
 
-func (c *Config) GetConfigFile() string {
-	return c.v.GetString("ConfigFile")
+func (c *Config) ConfigFileUsed() string {
+	return c.v.ConfigFileUsed()
 }
 
 func (c *Config) GetBool(key string) bool {

--- a/bridge/config/config.go
+++ b/bridge/config/config.go
@@ -66,6 +66,7 @@ type Protocol struct {
 	Buffer                 int    // api
 	Charset                string // irc
 	ColorNicks             bool   // only irc for now
+	ConfigURL              string // api
 	Debug                  bool   // general
 	DebugLevel             int    // only for irc now
 	EditSuffix             string // mattermost, slack, discord, telegram, gitter
@@ -172,6 +173,7 @@ type ConfigValues struct {
 	General            Protocol
 	Gateway            []Gateway
 	SameChannelGateway []SameChannelGateway
+	ConfigFile         string
 }
 
 type Config struct {
@@ -196,6 +198,9 @@ func NewConfig(cfgfile string) *Config {
 	viper.OnConfigChange(func(e fsnotify.Event) {
 		flog.Println("Config file changed:", e.Name)
 	})
+
+	mycfg.v.Set("ConfigFile", cfgfile)
+	mycfg.ConfigValues = &cfg
 	return mycfg
 }
 
@@ -227,6 +232,10 @@ func NewConfigFromString(input []byte) *Config {
 	mycfg.v = viper.GetViper()
 	mycfg.ConfigValues = &cfg
 	return mycfg
+}
+
+func (c *Config) GetConfigFile() string {
+	return c.v.GetString("ConfigFile")
 }
 
 func (c *Config) GetBool(key string) bool {

--- a/bridge/config/config.go
+++ b/bridge/config/config.go
@@ -197,9 +197,6 @@ func NewConfig(cfgfile string) *Config {
 	viper.OnConfigChange(func(e fsnotify.Event) {
 		flog.Println("Config file changed:", e.Name)
 	})
-
-	mycfg.v.Set("ConfigFile", cfgfile)
-
 	return mycfg
 }
 


### PR DESCRIPTION
Another run at \#525


Curious about feedback to approach, but still needs work:
- [ ] Debug output says config is reloaded, but channels are not updated. Any advice?

Notes:

- Using PUT instead of POST, since this is replacing an existing resource in full (the config file)
- no public viper methods to get config file location, so had to store it
- not sure best place to store `ConfigURL`, as it's global and never bridge-specific.
- not sure best place to doc in sample config file. Seems like General, but then people will be reading API when they need to know about it, so put it in the latter place :)

If it's alright with you Wim, I\'ll do the rest of the docs inline once Swagger
PR is merged? 

Related: #244