### PR TITLE
#510 New Slack connection and forked legacy Slack bridge

### DIFF
--- a/bridge/config/config.go
+++ b/bridge/config/config.go
@@ -163,6 +163,7 @@ type ConfigValues struct {
 	Mattermost         map[string]Protocol
 	Matrix             map[string]Protocol
 	Slack              map[string]Protocol
+	SlackLegacy        map[string]Protocol
 	Steam              map[string]Protocol
 	Gitter             map[string]Protocol
 	Xmpp               map[string]Protocol

--- a/bridge/slack/legacy.go
+++ b/bridge/slack/legacy.go
@@ -1,0 +1,74 @@
+package bslack
+
+import (
+	"errors"
+
+	"github.com/42wim/matterbridge/bridge"
+	"github.com/42wim/matterbridge/matterhook"
+	"github.com/nlopes/slack"
+)
+
+type BslackLegacy struct {
+	*Bslack
+}
+
+func NewLegacy(cfg *bridge.Config) bridge.Bridger {
+	return &BslackLegacy{Bslack: newBridge(cfg)}
+}
+
+func (b *BslackLegacy) Connect() error {
+	b.RLock()
+	defer b.RUnlock()
+	if b.GetString(incomingWebhookConfig) != "" {
+		switch {
+		case b.GetString(outgoingWebhookConfig) != "":
+			b.Log.Info("Connecting using webhookurl (sending) and webhookbindaddress (receiving)")
+			b.mh = matterhook.New(b.GetString(outgoingWebhookConfig), matterhook.Config{
+				InsecureSkipVerify: b.GetBool(skipTLSConfig),
+				BindAddress:        b.GetString(incomingWebhookConfig),
+			})
+		case b.GetString(tokenConfig) != "":
+			b.Log.Info("Connecting using token (sending)")
+			b.sc = slack.New(b.GetString(tokenConfig))
+			b.rtm = b.sc.NewRTM()
+			go b.rtm.ManageConnection()
+			b.Log.Info("Connecting using webhookbindaddress (receiving)")
+			b.mh = matterhook.New(b.GetString(outgoingWebhookConfig), matterhook.Config{
+				InsecureSkipVerify: b.GetBool(skipTLSConfig),
+				BindAddress:        b.GetString(incomingWebhookConfig),
+			})
+		default:
+			b.Log.Info("Connecting using webhookbindaddress (receiving)")
+			b.mh = matterhook.New(b.GetString(outgoingWebhookConfig), matterhook.Config{
+				InsecureSkipVerify: b.GetBool(skipTLSConfig),
+				BindAddress:        b.GetString(incomingWebhookConfig),
+			})
+		}
+		go b.handleSlack()
+		return nil
+	}
+	if b.GetString(outgoingWebhookConfig) != "" {
+		b.Log.Info("Connecting using webhookurl (sending)")
+		b.mh = matterhook.New(b.GetString(outgoingWebhookConfig), matterhook.Config{
+			InsecureSkipVerify: b.GetBool(skipTLSConfig),
+			DisableServer:      true,
+		})
+		if b.GetString(tokenConfig) != "" {
+			b.Log.Info("Connecting using token (receiving)")
+			b.sc = slack.New(b.GetString(tokenConfig))
+			b.rtm = b.sc.NewRTM()
+			go b.rtm.ManageConnection()
+			go b.handleSlack()
+		}
+	} else if b.GetString(tokenConfig) != "" {
+		b.Log.Info("Connecting using token (sending and receiving)")
+		b.sc = slack.New(b.GetString(tokenConfig))
+		b.rtm = b.sc.NewRTM()
+		go b.rtm.ManageConnection()
+		go b.handleSlack()
+	}
+	if b.GetString(incomingWebhookConfig) == "" && b.GetString(outgoingWebhookConfig) == "" && b.GetString(tokenConfig) == "" {
+		return errors.New("no connection method found. See that you have WebhookBindAddress, WebhookURL or Token configured")
+	}
+	return nil
+}

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -2,10 +2,15 @@ package gateway
 
 import (
 	"bytes"
+	"crypto/sha1"
 	"fmt"
 	"io/ioutil"
 	"net/http"
 	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
 
 	"github.com/42wim/matterbridge/bridge"
 	"github.com/42wim/matterbridge/bridge/api"
@@ -23,15 +28,8 @@ import (
 	bxmpp "github.com/42wim/matterbridge/bridge/xmpp"
 	bzulip "github.com/42wim/matterbridge/bridge/zulip"
 	"github.com/hashicorp/golang-lru"
-	log "github.com/sirupsen/logrus"
-	//	"github.com/davecgh/go-spew/spew"
-	"crypto/sha1"
-	"path/filepath"
-	"regexp"
-	"strings"
-	"time"
-
 	"github.com/peterhellberg/emojilib"
+	log "github.com/sirupsen/logrus"
 )
 
 type Gateway struct {
@@ -55,19 +53,20 @@ type BrMsgID struct {
 var flog *log.Entry
 
 var bridgeMap = map[string]bridge.Factory{
-	"api":        api.New,
-	"discord":    bdiscord.New,
-	"gitter":     bgitter.New,
-	"irc":        birc.New,
-	"mattermost": bmattermost.New,
-	"matrix":     bmatrix.New,
-	"rocketchat": brocketchat.New,
-	"slack":      bslack.New,
-	"sshchat":    bsshchat.New,
-	"steam":      bsteam.New,
-	"telegram":   btelegram.New,
-	"xmpp":       bxmpp.New,
-	"zulip":      bzulip.New,
+	"api":          api.New,
+	"discord":      bdiscord.New,
+	"gitter":       bgitter.New,
+	"irc":          birc.New,
+	"mattermost":   bmattermost.New,
+	"matrix":       bmatrix.New,
+	"rocketchat":   brocketchat.New,
+	"slack-legacy": bslack.NewLegacy,
+	"slack":        bslack.New,
+	"sshchat":      bsshchat.New,
+	"steam":        bsteam.New,
+	"telegram":     btelegram.New,
+	"xmpp":         bxmpp.New,
+	"zulip":        bzulip.New,
 }
 
 const (


### PR DESCRIPTION
Final commit for #510. This moves the existing Slack connection logic to a new `slack-legacy` bridge to maintain the possibility for users to continue to use the former logic as a conscious choice.

The new connection logic requires the use of a Slack bot-token which can be retrieved by installing a SlackApp to the targeted workspace (wiki documentation will be updated at merge of this PR). If a `Token` is specified in the Slack bridge's configuration only that will be used for exchanging messages, disregarding any specification of a `WebhookURL` or `WebhookBindAddress`. This does not preclude the bot messages from being sent with a modified nickname (see screenshot below):

<img width="235" alt="screenshot 2018-11-10 at 18 42 25" src="https://user-images.githubusercontent.com/896592/48304846-c14fac00-e518-11e8-8f60-7038fab571d5.png">
