### PR TITLE
Sync channel topics over gateway (slack)

### DIFF
--- a/bridge/config/config.go
+++ b/bridge/config/config.go
@@ -117,7 +117,7 @@ type Protocol struct {
 	ShowEmbeds             bool       // discord
 	SkipTLSVerify          bool       // IRC, mattermost
 	StripNick              bool       // all protocols
-	SyncTopicChange        bool       // slack
+	SyncTopic              bool       // slack
 	Team                   string     // mattermost
 	Token                  string     // gitter, slack, discord, api
 	Topic                  string     // zulip

--- a/bridge/config/config.go
+++ b/bridge/config/config.go
@@ -117,6 +117,7 @@ type Protocol struct {
 	ShowEmbeds             bool       // discord
 	SkipTLSVerify          bool       // IRC, mattermost
 	StripNick              bool       // all protocols
+	SyncTopicChange        bool       // slack
 	Team                   string     // mattermost
 	Token                  string     // gitter, slack, discord, api
 	Topic                  string     // zulip

--- a/bridge/slack/handlers.go
+++ b/bridge/slack/handlers.go
@@ -141,7 +141,6 @@ func (b *Bslack) skipMessageEvent(ev *slack.MessageEvent) bool {
 	if len(ev.Files) > 0 {
 		return b.filesCached(ev.Files)
 	}
-
 	return false
 }
 

--- a/bridge/slack/handlers.go
+++ b/bridge/slack/handlers.go
@@ -195,7 +195,7 @@ func (b *Bslack) handleMessageEvent(ev *slack.MessageEvent) (*config.Message, er
 	return rmsg, nil
 }
 
-func (b *Bslack) handleStatusEvent(ev *slack.MessageEvent, rmsg *config.Message) (doneProcessing bool) {
+func (b *Bslack) handleStatusEvent(ev *slack.MessageEvent, rmsg *config.Message) bool {
 	switch ev.SubType {
 	case sChannelJoined, sMemberJoined:
 		b.populateUsers()

--- a/bridge/slack/handlers.go
+++ b/bridge/slack/handlers.go
@@ -190,7 +190,7 @@ func (b *Bslack) handleMessageEvent(ev *slack.MessageEvent) (*config.Message, er
 	return rmsg, nil
 }
 
-func (b *Bslack) handleStatusEvent(ev *slack.MessageEvent, rmsg *config.Message) bool {
+func (b *Bslack) handleStatusEvent(ev *slack.MessageEvent, rmsg *config.Message) (doneProcessing bool) {
 	switch ev.SubType {
 	case sChannelJoined, sMemberJoined:
 		b.populateUsers()

--- a/bridge/slack/handlers.go
+++ b/bridge/slack/handlers.go
@@ -116,6 +116,11 @@ func (b *Bslack) skipMessageEvent(ev *slack.MessageEvent) bool {
 		return b.GetBool(noSendJoinConfig)
 	case sPinnedItem, sUnpinnedItem:
 		return true
+	case sChannelTopic, sChannelPurpose:
+		// Skip the event if our bot/user account changed the topic/purpose
+		if ev.User == b.si.User.ID {
+			return true
+		}
 	}
 
 	// Skip any messages that we made ourselves or from 'slackbot' (see #527).
@@ -201,6 +206,7 @@ func (b *Bslack) handleStatusEvent(ev *slack.MessageEvent, rmsg *config.Message)
 		rmsg.Username = sSystemUser
 		rmsg.Event = config.EventJoinLeave
 	case sChannelTopic, sChannelPurpose:
+		b.populateChannels()
 		rmsg.Event = config.EventTopicChange
 	case sMessageChanged:
 		rmsg.Text = ev.SubMessage.Text

--- a/bridge/slack/helpers.go
+++ b/bridge/slack/helpers.go
@@ -269,7 +269,7 @@ var (
 	topicOrPurposeRE = regexp.MustCompile(`(?s)(@.+) (cleared|set)(?: the)? channel (topic|purpose)(?:: (.*))?`)
 )
 
-func extractTopicOrPurpose(text string) (string, string) {
+func (b *Bslack) extractTopicOrPurpose(text string) (string, string) {
 	r := topicOrPurposeRE.FindStringSubmatch(text)
 	if len(r) == 5 {
 		action, updateType, extracted := r[2], r[3], r[4]
@@ -281,7 +281,7 @@ func extractTopicOrPurpose(text string) (string, string) {
 		}
 	}
 	b.Log.Warnf("Encountered channel topic or purpose change message with unexpected format: %s", text)
-	return unknown, ""
+	return "unknown", ""
 }
 
 // @see https://api.slack.com/docs/message-formatting#linking_to_channels_and_users

--- a/bridge/slack/helpers.go
+++ b/bridge/slack/helpers.go
@@ -271,7 +271,7 @@ var (
 
 func extractTopicOrPurpose(text string) (string, string) {
 	r := topicOrPurposeRE.FindStringSubmatch(text)
-	if len(r) >= 5 {
+	if len(r) == 5 {
 		action, updateType, extracted := r[2], r[3], r[4]
 		switch action {
 		case "set":
@@ -280,7 +280,8 @@ func extractTopicOrPurpose(text string) (string, string) {
 			return updateType, ""
 		}
 	}
-	return "unknown", ""
+	b.Log.Warnf("Encountered channel topic or purpose change message with unexpected format: %s", text)
+	return "unknown, ""
 }
 
 // @see https://api.slack.com/docs/message-formatting#linking_to_channels_and_users

--- a/bridge/slack/helpers.go
+++ b/bridge/slack/helpers.go
@@ -281,7 +281,7 @@ func extractTopicOrPurpose(text string) (string, string) {
 		}
 	}
 	b.Log.Warnf("Encountered channel topic or purpose change message with unexpected format: %s", text)
-	return "unknown, ""
+	return unknown, ""
 }
 
 // @see https://api.slack.com/docs/message-formatting#linking_to_channels_and_users

--- a/bridge/slack/helpers.go
+++ b/bridge/slack/helpers.go
@@ -266,15 +266,12 @@ var (
 	channelRE  = regexp.MustCompile(`<#[a-zA-Z0-9]+\|(.+?)>`)
 	variableRE = regexp.MustCompile(`<!((?:subteam\^)?[a-zA-Z0-9]+)(?:\|@?(.+?))?>`)
 	urlRE      = regexp.MustCompile(`<(.*?)(\|.*?)?>`)
-	topicOrPurposeRE    = regexp.MustCompile(`(?s)^@.+ set the channel (topic|purpose): (.+?)(\[nosync\])?$`)
+	topicOrPurposeRE    = regexp.MustCompile(`(?s)^@.+ set the channel (topic|purpose): (.+?)$`)
 )
 
 func (b *Bslack) extractTopicOrPurpose(text string) (updateType string, extracted string) {
 	r := topicOrPurposeRE.FindStringSubmatch(text)
-	updateType, extracted, noSync := r[1], r[2], r[3]
-	if noSync != "" {
-		return "nosync", ""
-	}
+	updateType, extracted = r[1], r[2]
 	return updateType, extracted
 }
 

--- a/bridge/slack/helpers.go
+++ b/bridge/slack/helpers.go
@@ -266,13 +266,19 @@ var (
 	channelRE        = regexp.MustCompile(`<#[a-zA-Z0-9]+\|(.+?)>`)
 	variableRE       = regexp.MustCompile(`<!((?:subteam\^)?[a-zA-Z0-9]+)(?:\|@?(.+?))?>`)
 	urlRE            = regexp.MustCompile(`<(.*?)(\|.*?)?>`)
-	topicOrPurposeRE = regexp.MustCompile(`(?s)^@.+ set the channel (topic|purpose): (.+?)$`)
+	topicOrPurposeRE = regexp.MustCompile(`(?s)(@.+) (cleared|set)(?: the)? channel (topic|purpose)(?:: (.*))?`)
 )
 
-func (b *Bslack) extractTopicOrPurpose(text string) (updateType string, extracted string) {
+func (b *Bslack) extractTopicOrPurpose(text string) (string, string) {
 	r := topicOrPurposeRE.FindStringSubmatch(text)
-	updateType, extracted = r[1], r[2]
-	return updateType, extracted
+	action, updateType, extracted := r[2], r[3], r[4]
+	switch action {
+	case "set":
+		return updateType, extracted
+	case "cleared":
+		return updateType, ""
+	}
+	return "", ""
 }
 
 // @see https://api.slack.com/docs/message-formatting#linking_to_channels_and_users

--- a/bridge/slack/helpers.go
+++ b/bridge/slack/helpers.go
@@ -262,11 +262,11 @@ func (b *Bslack) populateMessageWithBotInfo(ev *slack.MessageEvent, rmsg *config
 }
 
 var (
-	mentionRE  = regexp.MustCompile(`<@([a-zA-Z0-9]+)>`)
-	channelRE  = regexp.MustCompile(`<#[a-zA-Z0-9]+\|(.+?)>`)
-	variableRE = regexp.MustCompile(`<!((?:subteam\^)?[a-zA-Z0-9]+)(?:\|@?(.+?))?>`)
-	urlRE      = regexp.MustCompile(`<(.*?)(\|.*?)?>`)
-	topicOrPurposeRE    = regexp.MustCompile(`(?s)^@.+ set the channel (topic|purpose): (.+?)$`)
+	mentionRE        = regexp.MustCompile(`<@([a-zA-Z0-9]+)>`)
+	channelRE        = regexp.MustCompile(`<#[a-zA-Z0-9]+\|(.+?)>`)
+	variableRE       = regexp.MustCompile(`<!((?:subteam\^)?[a-zA-Z0-9]+)(?:\|@?(.+?))?>`)
+	urlRE            = regexp.MustCompile(`<(.*?)(\|.*?)?>`)
+	topicOrPurposeRE = regexp.MustCompile(`(?s)^@.+ set the channel (topic|purpose): (.+?)$`)
 )
 
 func (b *Bslack) extractTopicOrPurpose(text string) (updateType string, extracted string) {

--- a/bridge/slack/helpers.go
+++ b/bridge/slack/helpers.go
@@ -266,7 +266,17 @@ var (
 	channelRE  = regexp.MustCompile(`<#[a-zA-Z0-9]+\|(.+?)>`)
 	variableRE = regexp.MustCompile(`<!((?:subteam\^)?[a-zA-Z0-9]+)(?:\|@?(.+?))?>`)
 	urlRE      = regexp.MustCompile(`<(.*?)(\|.*?)?>`)
+	topicOrPurposeRE    = regexp.MustCompile(`(?s)^@.+ set the channel (topic|purpose): (.+?)(\[nosync\])?$`)
 )
+
+func (b *Bslack) extractTopicOrPurpose(text string) (updateType string, extracted string) {
+	r := topicOrPurposeRE.FindStringSubmatch(text)
+	updateType, extracted, noSync := r[1], r[2], r[3]
+	if noSync != "" {
+		return "nosync", ""
+	}
+	return updateType, extracted
+}
 
 // @see https://api.slack.com/docs/message-formatting#linking_to_channels_and_users
 func (b *Bslack) replaceMention(text string) string {

--- a/bridge/slack/helpers.go
+++ b/bridge/slack/helpers.go
@@ -269,16 +269,18 @@ var (
 	topicOrPurposeRE = regexp.MustCompile(`(?s)(@.+) (cleared|set)(?: the)? channel (topic|purpose)(?:: (.*))?`)
 )
 
-func (b *Bslack) extractTopicOrPurpose(text string) (string, string) {
+func extractTopicOrPurpose(text string) (string, string) {
 	r := topicOrPurposeRE.FindStringSubmatch(text)
-	action, updateType, extracted := r[2], r[3], r[4]
-	switch action {
-	case "set":
-		return updateType, extracted
-	case "cleared":
-		return updateType, ""
+	if len(r) >= 5 {
+		action, updateType, extracted := r[2], r[3], r[4]
+		switch action {
+		case "set":
+			return updateType, extracted
+		case "cleared":
+			return updateType, ""
+		}
 	}
-	return "", ""
+	return "unknown", ""
 }
 
 // @see https://api.slack.com/docs/message-formatting#linking_to_channels_and_users

--- a/bridge/slack/helpers_test.go
+++ b/bridge/slack/helpers_test.go
@@ -20,8 +20,9 @@ func TestExtractTopicOrPurpose(t *testing.T) {
 		"error - unhandled":      {"some unmatched message", "unknown", ""},
 	}
 
+	b := &Bslack{}
 	for name, tc := range testcases {
-		gotChangeType, gotOutput := extractTopicOrPurpose(tc.input)
+		gotChangeType, gotOutput := b.extractTopicOrPurpose(tc.input)
 
 		assert.Equalf(t, tc.wantChangeType, gotChangeType, "This testcase failed: %s", name)
 		assert.Equalf(t, tc.wantOutput, gotOutput, "This testcase failed: %s", name)

--- a/bridge/slack/helpers_test.go
+++ b/bridge/slack/helpers_test.go
@@ -1,0 +1,26 @@
+package bslack
+
+import (
+	"testing"
+)
+
+func TestExtractTopicOrPurpose(t *testing.T) {
+	tables := []struct{
+		input string
+		changeType string
+		output string
+	}{
+		{"@someone set channel topic: one liner",    "topic",   "one liner"},
+		{"@someone set channel purpose: one liner",  "purpose", "one liner"},
+		{"@someone set channel topic: multi\nliner", "topic",   "multi\nliner"},
+		{"@someone cleared channel topic",           "topic",   ""},
+		{"some unmatched message",                   "unknown", ""},
+	}
+
+	for _, table := range tables {
+		changeType, output := extractTopicOrPurpose(table.input)
+		if changeType != table.changeType || output != table.output {
+			t.Error()
+		}
+	}
+}

--- a/bridge/slack/helpers_test.go
+++ b/bridge/slack/helpers_test.go
@@ -2,13 +2,15 @@ package bslack
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestExtractTopicOrPurpose(t *testing.T) {
-	tables := []struct{
+	testcases := []struct{
 		input string
-		changeType string
-		output string
+		wantChangeType string
+		wantOutput string
 	}{
 		{"@someone set channel topic: one liner",    "topic",   "one liner"},
 		{"@someone set channel purpose: one liner",  "purpose", "one liner"},
@@ -17,10 +19,10 @@ func TestExtractTopicOrPurpose(t *testing.T) {
 		{"some unmatched message",                   "unknown", ""},
 	}
 
-	for _, table := range tables {
-		changeType, output := extractTopicOrPurpose(table.input)
-		if changeType != table.changeType || output != table.output {
-			t.Error()
-		}
+	for _, tc := range testcases {
+		gotChangeType, gotOutput := extractTopicOrPurpose(tc.input)
+
+		assert.Equal(t, tc.wantChangeType , gotChangeType)
+		assert.Equal(t, tc.wantOutput , gotOutput)
 	}
 }

--- a/bridge/slack/helpers_test.go
+++ b/bridge/slack/helpers_test.go
@@ -7,22 +7,23 @@ import (
 )
 
 func TestExtractTopicOrPurpose(t *testing.T) {
-	testcases := []struct {
+	testcases := map[string]struct {
 		input          string
 		wantChangeType string
 		wantOutput     string
 	}{
-		{"@someone set channel topic: one liner", "topic", "one liner"},
-		{"@someone set channel purpose: one liner", "purpose", "one liner"},
-		{"@someone set channel topic: multi\nliner", "topic", "multi\nliner"},
-		{"@someone cleared channel topic", "topic", ""},
-		{"some unmatched message", "unknown", ""},
+		"success - topic type": {"@someone set channel topic: foo bar", "topic", "foo bar"},
+		"success - purpose type": {"@someone set channel purpose: foo bar", "purpose", "foo bar"},
+		"success - one line": {"@someone set channel topic: foo bar", "topic", "foo bar"},
+		"success - multi-line": {"@someone set channel topic: foo\nbar", "topic", "foo\nbar"},
+		"success - cleared": {"@someone cleared channel topic", "topic", ""},
+		"error - unhandled": {"some unmatched message", "unknown", ""},
 	}
 
-	for _, tc := range testcases {
+	for name, tc := range testcases {
 		gotChangeType, gotOutput := extractTopicOrPurpose(tc.input)
 
-		assert.Equal(t, tc.wantChangeType, gotChangeType)
-		assert.Equal(t, tc.wantOutput, gotOutput)
+		assert.Equal(t, tc.wantChangeType, gotChangeType, "This testcase failed: " + name)
+		assert.Equal(t, tc.wantOutput, gotOutput, "This testcase failed: " + name)
 	}
 }

--- a/bridge/slack/helpers_test.go
+++ b/bridge/slack/helpers_test.go
@@ -23,7 +23,7 @@ func TestExtractTopicOrPurpose(t *testing.T) {
 	for name, tc := range testcases {
 		gotChangeType, gotOutput := extractTopicOrPurpose(tc.input)
 
-		assert.Equal(t, tc.wantChangeType, gotChangeType, "This testcase failed: " + name)
-		assert.Equal(t, tc.wantOutput, gotOutput, "This testcase failed: " + name)
+		assert.Equalf(t, tc.wantChangeType, gotChangeType, "This testcase failed: %s", name)
+		assert.Equalf(t, tc.wantOutput, gotOutput, "This testcase failed: %s", name)
 	}
 }

--- a/bridge/slack/helpers_test.go
+++ b/bridge/slack/helpers_test.go
@@ -7,22 +7,22 @@ import (
 )
 
 func TestExtractTopicOrPurpose(t *testing.T) {
-	testcases := []struct{
-		input string
+	testcases := []struct {
+		input          string
 		wantChangeType string
-		wantOutput string
+		wantOutput     string
 	}{
-		{"@someone set channel topic: one liner",    "topic",   "one liner"},
-		{"@someone set channel purpose: one liner",  "purpose", "one liner"},
-		{"@someone set channel topic: multi\nliner", "topic",   "multi\nliner"},
-		{"@someone cleared channel topic",           "topic",   ""},
-		{"some unmatched message",                   "unknown", ""},
+		{"@someone set channel topic: one liner", "topic", "one liner"},
+		{"@someone set channel purpose: one liner", "purpose", "one liner"},
+		{"@someone set channel topic: multi\nliner", "topic", "multi\nliner"},
+		{"@someone cleared channel topic", "topic", ""},
+		{"some unmatched message", "unknown", ""},
 	}
 
 	for _, tc := range testcases {
 		gotChangeType, gotOutput := extractTopicOrPurpose(tc.input)
 
-		assert.Equal(t, tc.wantChangeType , gotChangeType)
-		assert.Equal(t, tc.wantOutput , gotOutput)
+		assert.Equal(t, tc.wantChangeType, gotChangeType)
+		assert.Equal(t, tc.wantOutput, gotOutput)
 	}
 }

--- a/bridge/slack/helpers_test.go
+++ b/bridge/slack/helpers_test.go
@@ -12,12 +12,12 @@ func TestExtractTopicOrPurpose(t *testing.T) {
 		wantChangeType string
 		wantOutput     string
 	}{
-		"success - topic type": {"@someone set channel topic: foo bar", "topic", "foo bar"},
+		"success - topic type":   {"@someone set channel topic: foo bar", "topic", "foo bar"},
 		"success - purpose type": {"@someone set channel purpose: foo bar", "purpose", "foo bar"},
-		"success - one line": {"@someone set channel topic: foo bar", "topic", "foo bar"},
-		"success - multi-line": {"@someone set channel topic: foo\nbar", "topic", "foo\nbar"},
-		"success - cleared": {"@someone cleared channel topic", "topic", ""},
-		"error - unhandled": {"some unmatched message", "unknown", ""},
+		"success - one line":     {"@someone set channel topic: foo bar", "topic", "foo bar"},
+		"success - multi-line":   {"@someone set channel topic: foo\nbar", "topic", "foo\nbar"},
+		"success - cleared":      {"@someone cleared channel topic", "topic", ""},
+		"error - unhandled":      {"some unmatched message", "unknown", ""},
 	}
 
 	for name, tc := range testcases {

--- a/bridge/slack/helpers_test.go
+++ b/bridge/slack/helpers_test.go
@@ -1,8 +1,11 @@
 package bslack
 
 import (
+	"io/ioutil"
 	"testing"
 
+	"github.com/42wim/matterbridge/bridge"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -20,7 +23,10 @@ func TestExtractTopicOrPurpose(t *testing.T) {
 		"error - unhandled":      {"some unmatched message", "unknown", ""},
 	}
 
-	b := &Bslack{}
+	logger := logrus.New()
+	logger.SetOutput(ioutil.Discard)
+	cfg := &bridge.Config{Log: logger.WithFields(nil)}
+	b := newBridge(cfg)
 	for name, tc := range testcases {
 		gotChangeType, gotOutput := b.extractTopicOrPurpose(tc.input)
 

--- a/bridge/slack/slack.go
+++ b/bridge/slack/slack.go
@@ -324,7 +324,7 @@ func (b *Bslack) sendRTM(msg config.Message) (string, error) {
 func (b *Bslack) updateTopicOrPurpose(msg *config.Message, channelInfo *slack.Channel) (bool, error) {
 	var updateFunc func(channelID string, value string) (*slack.Channel, error)
 
-	incomingChangeType, text := extractTopicOrPurpose(msg.Text)
+	incomingChangeType, text := b.extractTopicOrPurpose(msg.Text)
 	switch incomingChangeType {
 	case "topic":
 		updateFunc = b.rtm.SetTopicOfConversation

--- a/bridge/slack/slack.go
+++ b/bridge/slack/slack.go
@@ -332,6 +332,7 @@ func (b *Bslack) updateTopicOrPurpose(msg *config.Message, channelInfo *slack.Ch
 		updateFunc = b.rtm.SetPurposeOfConversation
 	default:
 		b.Log.Errorf("Unhandled type received from extractTopicOrPurpose: %s", incomingChangeType)
+		return true, nil
 	}
 	for {
 		_, err := updateFunc(channelInfo.ID, text)

--- a/bridge/slack/slack.go
+++ b/bridge/slack/slack.go
@@ -269,7 +269,6 @@ func (b *Bslack) sendWebhook(msg config.Message) (string, error) {
 	return "", nil
 }
 
-// Note: returning an empty string skips the message
 func (b *Bslack) sendRTM(msg config.Message) (string, error) {
 	channelInfo, err := b.getChannel(msg.Channel)
 	if err != nil {
@@ -345,7 +344,7 @@ func (b *Bslack) updateTopicOrPurpose(msg *config.Message, channelInfo *slack.Ch
 	}
 }
 
-// handles updating topic/purpose and determining whether to further propagate update messages
+// handles updating topic/purpose and determining whether to further propagate update messages.
 func (b *Bslack) handleTopicOrPurpose(msg *config.Message, channelInfo *slack.Channel) (bool, error) {
 	if msg.Event != config.EVENT_TOPIC_CHANGE {
 		return false, nil
@@ -355,12 +354,12 @@ func (b *Bslack) handleTopicOrPurpose(msg *config.Message, channelInfo *slack.Ch
 		return b.updateTopicOrPurpose(msg, channelInfo)
 	}
 
-	// Pass along to normal message handlers
+	// Pass along to normal message handlers.
 	if b.GetBool("ShowTopicChange") {
 		return false, nil
 	}
 
-	// Swallow message as handled no-op
+	// Swallow message as handled no-op.
 	return true, nil
 }
 

--- a/bridge/slack/slack.go
+++ b/bridge/slack/slack.go
@@ -325,7 +325,7 @@ func (b *Bslack) sendRTM(msg config.Message) (string, error) {
 func (b *Bslack) updateTopicOrPurpose(msg *config.Message, channelInfo *slack.Channel) (bool, error) {
 	var updateFunc func(channelID string, value string) (*slack.Channel, error)
 
-	incomingChangeType, text := b.extractTopicOrPurpose(msg.Text)
+	incomingChangeType, text := extractTopicOrPurpose(msg.Text)
 	switch incomingChangeType {
 	case "topic":
 		updateFunc = b.rtm.SetTopicOfConversation

--- a/bridge/slack/slack.go
+++ b/bridge/slack/slack.go
@@ -349,7 +349,15 @@ func (b *Bslack) updateTopicOrPurpose(msg *config.Message, channelInfo *slack.Ch
 		if strings.HasSuffix(channelInfo.Purpose.Value, "[nosync]") {
 			break
 		}
-		_, err = b.rtm.SetPurposeOfConversation(channelInfo.ID, text)
+		for {
+			_, err = b.rtm.SetTopicOfConversation(channelInfo.ID, text)
+			if err == nil {
+				return true, nil
+			}
+			if err = b.handleRateLimit(err); err != nil {
+				return true, err
+			}
+		}
 	}
 
 	if err != nil {

--- a/bridge/slack/slack.go
+++ b/bridge/slack/slack.go
@@ -326,7 +326,7 @@ func (b *Bslack) updateTopicOrPurpose(msg *config.Message, channelInfo *slack.Ch
 		return false, nil
 	}
 
-	if !b.GetBool("SyncTopicChange") {
+	if !b.GetBool("SyncTopic") {
 		return false, nil
 	}
 

--- a/bridge/slack/slack.go
+++ b/bridge/slack/slack.go
@@ -336,7 +336,15 @@ func (b *Bslack) updateTopicOrPurpose(msg *config.Message, channelInfo *slack.Ch
 		if strings.HasSuffix(channelInfo.Topic.Value, "[nosync]") {
 			break
 		}
-		_, err = b.rtm.SetTopicOfConversation(channelInfo.ID, text)
+		for {
+			_, err = b.rtm.SetTopicOfConversation(channelInfo.ID, text)
+			if err == nil {
+				return true, nil
+			}
+			if err = b.handleRateLimit(err); err != nil {
+				return true, err
+			}
+		}
 	case "purpose":
 		if strings.HasSuffix(channelInfo.Purpose.Value, "[nosync]") {
 			break

--- a/bridge/slack/slack.go
+++ b/bridge/slack/slack.go
@@ -293,8 +293,6 @@ func (b *Bslack) sendRTM(msg config.Message) (string, error) {
 				break
 			}
 			b.rtm.SetPurposeOfConversation(channelInfo.ID, text)
-		case "nosync":
-			break
 		}
 		return "", nil
 	}

--- a/bridge/slack/slack.go
+++ b/bridge/slack/slack.go
@@ -280,6 +280,24 @@ func (b *Bslack) sendRTM(msg config.Message) (string, error) {
 		}
 		return "", nil
 	}
+	if (msg.Event == config.EVENT_TOPIC_CHANGE) && b.GetBool("SyncTopicChange") {
+		incomingChangeType, text := b.extractTopicOrPurpose(msg.Text)
+		switch incomingChangeType {
+		case "topic":
+			if strings.HasSuffix(channelInfo.Topic.Value, "[nosync]") {
+				break
+			}
+			b.rtm.SetTopicOfConversation(channelInfo.ID, text)
+		case "purpose":
+			if strings.HasSuffix(channelInfo.Purpose.Value, "[nosync]") {
+				break
+			}
+			b.rtm.SetPurposeOfConversation(channelInfo.ID, text)
+		case "nosync":
+			break
+		}
+		return "", nil
+	}
 
 	// Handle message deletions.
 	var handled bool

--- a/bridge/slack/slack.go
+++ b/bridge/slack/slack.go
@@ -346,7 +346,7 @@ func (b *Bslack) updateTopicOrPurpose(msg *config.Message, channelInfo *slack.Ch
 
 // handles updating topic/purpose and determining whether to further propagate update messages.
 func (b *Bslack) handleTopicOrPurpose(msg *config.Message, channelInfo *slack.Channel) (bool, error) {
-	if msg.Event != config.EVENT_TOPIC_CHANGE {
+	if msg.Event != config.EventTopicChange {
 		return false, nil
 	}
 

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -279,7 +279,6 @@ func (gw *Gateway) handleMessage(msg config.Message, dest *bridge.Bridge) []*BrM
 		}
 	}
 
-
 	// broadcast to every out channel (irc QUIT)
 	if msg.Channel == "" && msg.Event != config.EventJoinLeave {
 		flog.Debug("empty channel")

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -274,7 +274,7 @@ func (gw *Gateway) handleMessage(msg config.Message, dest *bridge.Bridge) []*BrM
 			return brMsgIDs
 		}
 		// don't relay topic/purpose update if sync is enabled, but msg marked as nosync
-		if gw.Bridges[dest.Account].GetBool("SyncTopicChange") && strings.HasSuffix(msg.Text, "[nosync]") {
+		if gw.Bridges[dest.Account].GetBool("SyncTopic") && strings.HasSuffix(msg.Text, "[nosync]") {
 			return brMsgIDs
 		}
 	}

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -267,16 +267,11 @@ func (gw *Gateway) handleMessage(msg config.Message, dest *bridge.Bridge) []*BrM
 		return brMsgIDs
 	}
 
-	// only relay topic change when configured
-	if msg.Event == config.EventTopicChange && !gw.Bridges[dest.Account].GetBool("ShowTopicChange") {
-		// don't relay topic/purpose change if disabled
-		if !gw.Bridges[dest.Account].GetBool("ShowTopicChange") {
-			return brMsgIDs
-		}
-		// don't relay topic/purpose update if sync is enabled
-		if gw.Bridges[dest.Account].GetBool("SyncTopic") {
-			return brMsgIDs
-		}
+	// only relay topic change when used in some way on other side
+	if msg.Event == config.EventTopicChange &&
+		!gw.Bridges[dest.Account].GetBool("ShowTopicChange") &&
+		!gw.Bridges[dest.Account].GetBool("SyncTopic") {
+		return brMsgIDs
 	}
 
 	// broadcast to every out channel (irc QUIT)

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -273,8 +273,8 @@ func (gw *Gateway) handleMessage(msg config.Message, dest *bridge.Bridge) []*BrM
 		if !gw.Bridges[dest.Account].GetBool("ShowTopicChange") {
 			return brMsgIDs
 		}
-		// don't relay topic/purpose update if sync is enabled, but msg marked as nosync
-		if gw.Bridges[dest.Account].GetBool("SyncTopic") && strings.HasSuffix(msg.Text, "[nosync]") {
+		// don't relay topic/purpose update if sync is enabled
+		if gw.Bridges[dest.Account].GetBool("SyncTopic") {
 			return brMsgIDs
 		}
 	}

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -269,8 +269,16 @@ func (gw *Gateway) handleMessage(msg config.Message, dest *bridge.Bridge) []*BrM
 
 	// only relay topic change when configured
 	if msg.Event == config.EventTopicChange && !gw.Bridges[dest.Account].GetBool("ShowTopicChange") {
-		return brMsgIDs
+		// don't relay topic/purpose change if disabled
+		if !gw.Bridges[dest.Account].GetBool("ShowTopicChange") {
+			return brMsgIDs
+		}
+		// don't relay topic/purpose update if sync is enabled, but msg marked as nosync
+		if gw.Bridges[dest.Account].GetBool("SyncTopicChange") && strings.HasSuffix(msg.Text, "[nosync]") {
+			return brMsgIDs
+		}
 	}
+
 
 	// broadcast to every out channel (irc QUIT)
 	if msg.Channel == "" && msg.Event != config.EventJoinLeave {

--- a/matterbridge.toml.sample
+++ b/matterbridge.toml.sample
@@ -772,9 +772,8 @@ ShowTopicChange=false
 
 #Enable to sync topic/purpose changes from other bridges
 #Only works syncing topic changes from slack bridge for now
-#Appending "[nosync]" to the topic/purpose will protect it from being synced
 #OPTIONAL (default false)
-SyncTopicChange=false
+SyncTopic=false
 
 ###################################################################
 #telegram section

--- a/matterbridge.toml.sample
+++ b/matterbridge.toml.sample
@@ -765,10 +765,16 @@ ShowJoinPart=false
 #OPTIONAL (default false)
 StripNick=false
 
-#Enable to show topic changes from other bridges 
+#Enable to show topic/purpose changes from other bridges
 #Only works hiding/show topic changes from slack bridge for now
 #OPTIONAL (default false)
 ShowTopicChange=false
+
+#Enable to sync topic/purpose changes from other bridges
+#Only works syncing topic changes from slack bridge for now
+#Appending "[nosync]" to the topic/purpose will protect it from being synced
+#OPTIONAL (default false)
+SyncTopicChange=false
 
 ###################################################################
 #telegram section


### PR DESCRIPTION
**Is your feature request related to a problem? Please describe.**
Keeping topic messages sync'd between Slacks can be burdensome. But without syncing, having different information on each channel can be confusing.

**Describe the solution you'd like**
When `SyncChannelTopics` is set to true, updating a topic in one channel would update it in others across gateway, when possible. MVP would just be across Slack teams.

A known pattern would prevent the topic from being set. For example, ending the topic with `[lock]` might prevent it from being modified by changes in other bridges (and reciprocally, updates with that pattern wouldn't be propagated).

Future extensions of feature:
- Apply same logic for channel purpose with `SyncChannelPurposes`.
- Extend feature to work for non-Slack protocols.

**Describe alternatives you've considered**
- `ShowTopicChange` covers some of this: https://github.com/42wim/matterbridge/issues/353#issuecomment-362693052

**Additional context**
None.

![screen shot 2018-11-13 at 5 50 25 pm](https://user-images.githubusercontent.com/305339/48405132-b2f9ce00-e76c-11e8-91ad-3b8464670aec.png)
