### PR TITLE
Make config.Config more unit-test friendly

### DIFF
--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -22,7 +22,7 @@ type Bridge struct {
 	Channels map[string]config.ChannelInfo
 	Joined   map[string]bool
 	Log      *log.Entry
-	Config   *config.Config
+	Config   config.Config
 	General  *config.Protocol
 }
 
@@ -69,36 +69,41 @@ func (b *Bridge) joinChannels(channels map[string]config.ChannelInfo, exists map
 }
 
 func (b *Bridge) GetBool(key string) bool {
-	if b.Config.GetBool(b.Account + "." + key) {
-		return b.Config.GetBool(b.Account + "." + key)
+	val, ok := b.Config.GetBool(b.Account + "." + key)
+	if !ok {
+		val, _ = b.Config.GetBool("general." + key)
 	}
-	return b.Config.GetBool("general." + key)
+	return val
 }
 
 func (b *Bridge) GetInt(key string) int {
-	if b.Config.GetInt(b.Account+"."+key) != 0 {
-		return b.Config.GetInt(b.Account + "." + key)
+	val, ok := b.Config.GetInt(b.Account + "." + key)
+	if !ok {
+		val, _ = b.Config.GetInt("general." + key)
 	}
-	return b.Config.GetInt("general." + key)
+	return val
 }
 
 func (b *Bridge) GetString(key string) string {
-	if b.Config.GetString(b.Account+"."+key) != "" {
-		return b.Config.GetString(b.Account + "." + key)
+	val, ok := b.Config.GetString(b.Account + "." + key)
+	if !ok {
+		val, _ = b.Config.GetString("general." + key)
 	}
-	return b.Config.GetString("general." + key)
+	return val
 }
 
 func (b *Bridge) GetStringSlice(key string) []string {
-	if len(b.Config.GetStringSlice(b.Account+"."+key)) != 0 {
-		return b.Config.GetStringSlice(b.Account + "." + key)
+	val, ok := b.Config.GetStringSlice(b.Account + "." + key)
+	if !ok {
+		val, _ = b.Config.GetStringSlice("general." + key)
 	}
-	return b.Config.GetStringSlice("general." + key)
+	return val
 }
 
 func (b *Bridge) GetStringSlice2D(key string) [][]string {
-	if len(b.Config.GetStringSlice2D(b.Account+"."+key)) != 0 {
-		return b.Config.GetStringSlice2D(b.Account + "." + key)
+	val, ok := b.Config.GetStringSlice2D(b.Account + "." + key)
+	if !ok {
+		val, _ = b.Config.GetStringSlice2D("general." + key)
 	}
-	return b.Config.GetStringSlice2D("general." + key)
+	return val
 }

--- a/gateway/router.go
+++ b/gateway/router.go
@@ -2,27 +2,32 @@ package gateway
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/42wim/matterbridge/bridge"
 	"github.com/42wim/matterbridge/bridge/config"
 	samechannelgateway "github.com/42wim/matterbridge/gateway/samechannel"
-	//	"github.com/davecgh/go-spew/spew"
-	"time"
 )
 
 type Router struct {
+	config.Config
+
 	Gateways         map[string]*Gateway
 	Message          chan config.Message
 	MattermostPlugin chan config.Message
-	*config.Config
 }
 
-func NewRouter(cfg *config.Config) (*Router, error) {
-	r := &Router{Message: make(chan config.Message), MattermostPlugin: make(chan config.Message), Gateways: make(map[string]*Gateway), Config: cfg}
+func NewRouter(cfg config.Config) (*Router, error) {
+	r := &Router{
+		Config:           cfg,
+		Message:          make(chan config.Message),
+		MattermostPlugin: make(chan config.Message),
+		Gateways:         make(map[string]*Gateway),
+	}
 	sgw := samechannelgateway.New(cfg)
 	gwconfigs := sgw.GetConfig()
 
-	for _, entry := range append(gwconfigs, cfg.Gateway...) {
+	for _, entry := range append(gwconfigs, cfg.ConfigValues().Gateway...) {
 		if !entry.Enable {
 			continue
 		}

--- a/gateway/samechannel/samechannel.go
+++ b/gateway/samechannel/samechannel.go
@@ -5,17 +5,17 @@ import (
 )
 
 type SameChannelGateway struct {
-	*config.Config
+	config.Config
 }
 
-func New(cfg *config.Config) *SameChannelGateway {
+func New(cfg config.Config) *SameChannelGateway {
 	return &SameChannelGateway{Config: cfg}
 }
 
 func (sgw *SameChannelGateway) GetConfig() []config.Gateway {
 	var gwconfigs []config.Gateway
 	cfg := sgw.Config
-	for _, gw := range cfg.SameChannelGateway {
+	for _, gw := range cfg.ConfigValues().SameChannelGateway {
 		gwconfig := config.Gateway{Name: gw.Name, Enable: gw.Enable}
 		for _, account := range gw.Accounts {
 			for _, channel := range gw.Channels {

--- a/gateway/samechannel/samechannel_test.go
+++ b/gateway/samechannel/samechannel_test.go
@@ -1,16 +1,13 @@
 package samechannelgateway
 
 import (
-	"fmt"
-
 	"github.com/42wim/matterbridge/bridge/config"
-	"github.com/BurntSushi/toml"
 	"github.com/stretchr/testify/assert"
 
 	"testing"
 )
 
-var testconfig = `
+const testConfig = `
 [mattermost.test]
 [slack.test]
 
@@ -21,12 +18,56 @@ var testconfig = `
       channels = [ "testing","testing2","testing10"]
 `
 
-func TestGetConfig(t *testing.T) {
-	var cfg *config.Config
-	if _, err := toml.Decode(testconfig, &cfg); err != nil {
-		fmt.Println(err)
+var (
+	expectedConfig = config.Gateway{
+		Name:   "blah",
+		Enable: true,
+		In:     []config.Bridge(nil),
+		Out:    []config.Bridge(nil),
+		InOut: []config.Bridge{
+			{
+				Account:     "mattermost.test",
+				Channel:     "testing",
+				Options:     config.ChannelOptions{Key: ""},
+				SameChannel: true,
+			},
+			{
+				Account:     "mattermost.test",
+				Channel:     "testing2",
+				Options:     config.ChannelOptions{Key: ""},
+				SameChannel: true,
+			},
+			{
+				Account:     "mattermost.test",
+				Channel:     "testing10",
+				Options:     config.ChannelOptions{Key: ""},
+				SameChannel: true,
+			},
+			{
+				Account:     "slack.test",
+				Channel:     "testing",
+				Options:     config.ChannelOptions{Key: ""},
+				SameChannel: true,
+			},
+			{
+				Account:     "slack.test",
+				Channel:     "testing2",
+				Options:     config.ChannelOptions{Key: ""},
+				SameChannel: true,
+			},
+			{
+				Account:     "slack.test",
+				Channel:     "testing10",
+				Options:     config.ChannelOptions{Key: ""},
+				SameChannel: true,
+			},
+		},
 	}
+)
+
+func TestGetConfig(t *testing.T) {
+	cfg := config.NewConfigFromString([]byte(testConfig))
 	sgw := New(cfg)
 	configs := sgw.GetConfig()
-	assert.Equal(t, []config.Gateway{{Name: "blah", Enable: true, In: []config.Bridge(nil), Out: []config.Bridge(nil), InOut: []config.Bridge{{Account: "mattermost.test", Channel: "testing", Options: config.ChannelOptions{Key: ""}, SameChannel: true}, {Account: "mattermost.test", Channel: "testing2", Options: config.ChannelOptions{Key: ""}, SameChannel: true}, {Account: "mattermost.test", Channel: "testing10", Options: config.ChannelOptions{Key: ""}, SameChannel: true}, {Account: "slack.test", Channel: "testing", Options: config.ChannelOptions{Key: ""}, SameChannel: true}, {Account: "slack.test", Channel: "testing2", Options: config.ChannelOptions{Key: ""}, SameChannel: true}, {Account: "slack.test", Channel: "testing10", Options: config.ChannelOptions{Key: ""}, SameChannel: true}}}}, configs)
+	assert.Equal(t, []config.Gateway{expectedConfig}, configs)
 }

--- a/matterbridge.go
+++ b/matterbridge.go
@@ -44,7 +44,7 @@ func main() {
 		flog.Println("WARNING: THIS IS A DEVELOPMENT VERSION. Things may break.")
 	}
 	cfg := config.NewConfig(*flagConfig)
-	cfg.General.Debug = *flagDebug
+	cfg.ConfigValues().General.Debug = *flagDebug
 	r, err := gateway.NewRouter(cfg)
 	if err != nil {
 		flog.Fatalf("Starting gateway failed: %s", err)


### PR DESCRIPTION
## Making config.Config more unit-test friendly
In its current implementation the `config.Config` struct is not very welcoming to easily implement unit-tests that depend on a particular config value being set. This is mostly due to the inability to override values on the fly because the `viper.Viper` object included in `config.Config` is not exported (for good reason).

This PR proposes to solve this UX issue by:
1. Changing `config.Config` to make it an interface and moving the actual implementation into an unexported `config.config` struct. We already have factory methods anyway, limiting the code impact of this change outside of the package.
2. Implementing a `config.TestConfig` exported struct that implements `config.Config` but also allows for providing easy overrides for specific configuration values.

## Moving config-value retrieval to a two-value return model
In the process of doing this and testing its potential applications I also uncovered some strangeness / a potential bug in the implementation of the `Get<Type>()` methods of the current `config.Config` methods. This was due to the fact that these methods did not implement a two-value return but rather a single-value one. This made it impossible to distinguish between a value being set to the retrieved type's default instance or a value not being set, which in turn made the implementation logic quite dodgy and constrained.

The fix for this is luckily not too massive as the `config.Config` is only really accessed through `bridge.Config` which has its own `Get<Type>()` methods. We might want to move those as well to a two-value return model but that would be a much bigger PR and it is not fundamentally necessary at this point in time.