### PR TITLE
[WIP] add base protocol concept to improve shared state between compatible bridge protocols

### DIFF
--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -68,6 +68,10 @@ func (b *Bridge) joinChannels(channels map[string]config.ChannelInfo, exists map
 	return nil
 }
 
+func (b *Bridge) BaseProtocol() string {
+	return strings.Split(b.Protocol, "-")[0]
+}
+
 func (b *Bridge) GetBool(key string) bool {
 	val, ok := b.Config.GetBool(b.Account + "." + key)
 	if !ok {

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -280,7 +280,7 @@ func (gw *Gateway) handleMessage(msg config.Message, dest *bridge.Bridge) []*BrM
 	// Get the ID of the parent message in thread
 	var canonicalParentMsgID string
 	if msg.ParentID != "" && (gw.BridgeValues().General.PreserveThreading || dest.GetBool("PreserveThreading")) {
-		thisParentMsgID := dest.Protocol + " " + msg.ParentID
+		thisParentMsgID := dest.BaseProtocol() + " " + msg.ParentID
 		canonicalParentMsgID = gw.FindCanonicalMsgID(thisParentMsgID)
 	}
 
@@ -428,7 +428,7 @@ func (gw *Gateway) modifyUsername(msg config.Message, dest *bridge.Bridge) strin
 	}
 
 	nick = strings.Replace(nick, "{BRIDGE}", br.Name, -1)
-	nick = strings.Replace(nick, "{PROTOCOL}", br.Protocol, -1)
+	nick = strings.Replace(nick, "{PROTOCOL}", br.BaseProtocol(), -1)
 	nick = strings.Replace(nick, "{GATEWAY}", gw.Name, -1)
 	nick = strings.Replace(nick, "{LABEL}", br.GetString("Label"), -1)
 	nick = strings.Replace(nick, "{NICK}", msg.Username, -1)


### PR DESCRIPTION
mIDs are stored in cache as `slack <id>`, but msg.ParentID is generalized and so looks up by looking for `<protocol> <id>`

So with `slack-legacy`, it's looking for `slack-legacy <id>`, when they are instead stored as `slack <id>`.

## Suggestion

We could make a general convention about some specific character in protocol names being used to specify sub-protocols that are cross-compatible aside from connection methods. Then, we could split on that character, and get the root protocol for cache.

I'm happy for that character to remain as "hyphen". The only reason to choose something else might be bc it's so common in namespaces. Another char might "make itself known" more candidly to future explorers. Maybe "/"? Minor though :)