### PR TITLE
Hint at thread replies when messages are unthreaded

### DIFF
--- a/bridge/config/config.go
+++ b/bridge/config/config.go
@@ -42,6 +42,17 @@ type Message struct {
 	Extra     map[string][]interface{}
 }
 
+func (msg *Message) CanonicalParentMsgID() string {
+	if msg.Extra != nil && len(msg.Extra["canonical_parent_mid"]) == 1 {
+		return msg.Extra["canonical_parent_mid"][0].(string)
+	}
+	return ""
+}
+
+func (msg *Message) IsThreadable() bool {
+	return msg.CanonicalParentMsgID() != ""
+}
+
 type FileInfo struct {
 	Name    string
 	Data    *[]byte

--- a/bridge/slack/helpers.go
+++ b/bridge/slack/helpers.go
@@ -189,6 +189,13 @@ func (b *Bslack) populateReceivedMessage(ev *slack.MessageEvent) (*config.Messag
 		}
 	}
 
+	// For edits, only submessage has thread ts.
+	// Ensures edits to threaded messages maintain their prefix hint on the
+	// unthreaded end.
+	if ev.SubMessage != nil {
+		rmsg.ParentID = ev.SubMessage.ThreadTimestamp
+	}
+
 	if err = b.populateMessageWithUserInfo(ev, rmsg); err != nil {
 		return nil, err
 	}

--- a/bridge/slack/slack.go
+++ b/bridge/slack/slack.go
@@ -288,6 +288,12 @@ func (b *Bslack) sendRTM(msg config.Message) (string, error) {
 		return "", err
 	}
 
+	// Handle prefix hint for unthreaded messages.
+	if msg.ParentID == "unthreaded" {
+		msg.ParentID = ""
+		msg.Text = fmt.Sprintf("thread reply: %s", msg.Text)
+	}
+
 	// Handle message deletions.
 	if handled, err = b.deleteMessage(&msg, channelInfo); handled {
 		return msg.ID, err

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -263,7 +263,7 @@ func (gw *Gateway) handleMessage(msg config.Message, dest *bridge.Bridge) []*BrM
 	channels := gw.getDestChannel(&msg, *dest)
 	for _, channel := range channels {
 		// Performs rethreading.
-		msg.ParentID =  gw.getParentID(&msg, dest, channel)
+		msg.ParentID = gw.getParentID(&msg, dest, channel)
 
 		// Only send the avatar download event to ourselves.
 		if msg.Event == config.EventAvatarDownload {

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -41,7 +41,8 @@ type BrMsgID struct {
 var flog *log.Entry
 
 const (
-	apiProtocol = "api"
+	apiProtocol       = "api"
+	threadReplyPrefix = "thread reply"
 )
 
 func New(cfg config.Gateway, r *Router) *Gateway {
@@ -286,6 +287,11 @@ func (gw *Gateway) handleMessage(msg config.Message, dest *bridge.Bridge) []*BrM
 		// for api we need originchannel as channel
 		if dest.Protocol == apiProtocol {
 			msg.Channel = originchannel
+		}
+
+		// Add prefix if reply message is being unthreaded.
+		if msg.ParentID != "" && canonicalParentMsgID == "" {
+			msg.Text = fmt.Sprintf("%s: %s", threadReplyPrefix, msg.Text)
 		}
 
 		msg.ParentID = gw.getDestMsgID(origmsg.Protocol+" "+canonicalParentMsgID, dest, channel)


### PR DESCRIPTION
Lighter touch approach to https://github.com/42wim/matterbridge/issues/343

**Is your feature request related to a problem? Please describe.**
Unthreaded messages confuse the flow. It's a very different experience on different ends of bridge, depending on if messages are threaded or not.

**Describe the solution you'd like**
Let's offer a small hint when things become unthreaded. For example, just prefix unthreaded messages with `thread reply: `. If that formatting is contentious, happy to use another. We could also template this, so that folks could override the default template of `thread reply: {MESSAGE}`.

**Describe alternatives you've considered**
- preserving threading when possible #529
- quoting parent message #343

**Additional context**
None.