### PR TITLE
Add protocol to msg.ID in cache

### DIFF
--- a/bridge/slack/slack.go
+++ b/bridge/slack/slack.go
@@ -321,10 +321,8 @@ func (b *Bslack) deleteMessage(msg *config.Message, channelInfo *slack.Channel) 
 		return true, nil
 	}
 
-	// If we get a "slack <ID>", split it.
-	ts := strings.Fields(msg.ID)
 	for {
-		_, _, err := b.rtm.DeleteMessage(channelInfo.ID, ts[1])
+		_, _, err := b.rtm.DeleteMessage(channelInfo.ID, msg.ID)
 		if err == nil {
 			return true, nil
 		}
@@ -341,9 +339,8 @@ func (b *Bslack) editMessage(msg *config.Message, channelInfo *slack.Channel) (b
 		return false, nil
 	}
 
-	ts := strings.Fields(msg.ID)
 	for {
-		_, _, _, err := b.rtm.UpdateMessage(channelInfo.ID, ts[1], msg.Text)
+		_, _, _, err := b.rtm.UpdateMessage(channelInfo.ID, msg.ID, msg.Text)
 		if err == nil {
 			return true, nil
 		}
@@ -359,7 +356,7 @@ func (b *Bslack) postMessage(msg *config.Message, messageParameters *slack.PostM
 	for {
 		_, id, err := b.rtm.PostMessage(channelInfo.ID, msg.Text, *messageParameters)
 		if err == nil {
-			return "slack " + id, nil
+			return id, nil
 		}
 
 		if err = b.handleRateLimit(err); err != nil {

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -228,13 +228,13 @@ func (gw *Gateway) getDestChannel(msg *config.Message, dest bridge.Bridge) []con
 }
 
 func (gw *Gateway) getDestMsgID(msgID string, dest *bridge.Bridge, channel config.ChannelInfo) string {
-	if res, ok := gw.Messages.Get(msgID); ok {
+	if res, ok := gw.Messages.Get(dest.Protocol + " " + msgID); ok {
 		IDs := res.([]*BrMsgID)
 		for _, id := range IDs {
 			// check protocol, bridge name and channelname
 			// for people that reuse the same bridge multiple times. see #342
 			if dest.Protocol == id.br.Protocol && dest.Name == id.br.Name && channel.ID == id.ChannelID {
-				return id.ID
+				return strings.Replace(id.ID, dest.Protocol+" ", "", 1)
 			}
 		}
 	}

--- a/gateway/router.go
+++ b/gateway/router.go
@@ -109,8 +109,8 @@ func (r *Router) handleReceive() {
 					msgIDs = append(msgIDs, gw.handleMessage(msg, br)...)
 				}
 				// only add the message ID if it doesn't already exists
-				if _, ok := gw.Messages.Get(msg.ID); !ok && msg.ID != "" {
-					gw.Messages.Add(msg.ID, msgIDs)
+				if _, ok := gw.Messages.Get(msg.Protocol + " " + msg.ID); !ok && msg.ID != "" {
+					gw.Messages.Add(msg.Protocol+" "+msg.ID, msgIDs)
 				}
 			}
 		}


### PR DESCRIPTION
This is a more generic solution for #594 and I fixes slack not always returning `slack id`
We now prepend the protocol of each bridge to each msgID that gets cached (and remove it again when sending it back to the bridge)