### PR TITLE
Make sure threaded files stay in thread (slack). Fixes #590

### DIFF
--- a/bridge/slack/slack.go
+++ b/bridge/slack/slack.go
@@ -356,6 +356,10 @@ func (b *Bslack) editMessage(msg *config.Message, channelInfo *slack.Channel) (b
 }
 
 func (b *Bslack) postMessage(msg *config.Message, messageParameters *slack.PostMessageParameters, channelInfo *slack.Channel) (string, error) {
+	// don't post empty messages
+	if msg.Text == "" {
+		return "", nil
+	}
 	for {
 		_, id, err := b.rtm.PostMessage(channelInfo.ID, msg.Text, *messageParameters)
 		if err == nil {

--- a/bridge/slack/slack.go
+++ b/bridge/slack/slack.go
@@ -389,11 +389,16 @@ func (b *Bslack) uploadFile(msg *config.Message, channelID string) {
 		ts := time.Now()
 		b.Log.Debugf("Adding file %s to cache at %s with timestamp", fi.Name, ts.String())
 		b.cache.Add("filename"+fi.Name, ts)
+		initialComment := fmt.Sprintf("File from %s", msg.Username)
+		if fi.Comment != "" {
+			initialComment += fmt.Sprintf("with comment: %s", fi.Comment)
+		}
 		res, err := b.sc.UploadFile(slack.FileUploadParameters{
-			Reader:         bytes.NewReader(*fi.Data),
-			Filename:       fi.Name,
-			Channels:       []string{channelID},
-			InitialComment: fi.Comment,
+			Reader:          bytes.NewReader(*fi.Data),
+			Filename:        fi.Name,
+			Channels:        []string{channelID},
+			InitialComment:  initialComment,
+			ThreadTimestamp: msg.ParentID,
 		})
 		if err != nil {
 			b.Log.Errorf("uploadfile %#v", err)


### PR DESCRIPTION
@patcon please test :)
It doesn't seem possible to impersonate the user that uploads the file, I've tried it using a legacy api token and a new bot token.

Also no hints on https://api.slack.com/methods/files.upload that this is possible

@Helcaraxan any ideas ?