### PR TITLE
Remove double " from Discord gateway webhookurl=

### DIFF
--- a/matterbridge.toml.sample
+++ b/matterbridge.toml.sample
@@ -1389,7 +1389,7 @@ enable=true
 
         #OPTIONAL - webhookurl only works for discord (it needs a different URL for each cahnnel)
         [gateway.inout.options]
-        webhookurl=""https://discordapp.com/api/webhooks/123456789123456789/C9WPqExYWONPDZabcdef-def1434FGFjstasJX9pYht73y"
+        webhookurl="https://discordapp.com/api/webhooks/123456789123456789/C9WPqExYWONPDZabcdef-def1434FGFjstasJX9pYht73y"
 
     #API example
     #[[gateway.inout]]


### PR DESCRIPTION
A tiny correction, I know. Just removing the double quotation marks from the webhookurl parameters for the Discord gateway example.