### PR TITLE
Start documenting test scenarios

### DIFF
--- a/internal/features/threading/replies.feature
+++ b/internal/features/threading/replies.feature
@@ -55,3 +55,9 @@ Feature: Thread Reply support
     And I delete the parent message in #foo
     And I post another reply in #bar
     Then the final reply should appear in #foo
+
+  Scenario: User replies back across subprotocols
+    Given I have a simple gateway between slack#foo, slack#bar and slack-legacy#baz
+    And I post a message in #foo
+    And I post a reply in #baz
+    Then the reply should appear in #foo and #bar

--- a/internal/features/threading/replies.feature
+++ b/internal/features/threading/replies.feature
@@ -1,0 +1,57 @@
+@replies
+Feature: Thread Reply support
+
+  Scenario: User replies to message with threading disabled
+
+  Scenario: User replies to uncached message with unthreading
+
+  Scenario: User replies to unthreaded message
+
+  Scenario: User replies to own message
+    Given I have a simple gateway between #foo and #bar
+    And I post a message in #foo
+    And I post a reply in #foo
+    Then a reply should appear in #bar
+
+  Scenario: User replies to relayed message
+    Given I have a simple gateway between #foo and #bar
+    And I post a message in #foo
+    And I post a reply in #bar
+    Then a reply should appear in #foo
+
+  Scenario: User edits a reply message
+    Given I have a simple gateway between #foo and #bar
+    And I post a message in #foo
+    And I post a reply in #bar
+    And I edit the reply
+    Then the edited reply should appear in #foo
+
+  Scenario: User deletes a reply message
+    Given I have a simple gateway between #foo and #bar
+    And I post a message in #foo
+    And I post a reply in #bar
+    And I delete the reply
+    Then the deleted reply should not appear in #foo
+
+  Scenario: User deletes a parent message
+    Given I have a simple gateway between #foo and #bar
+    And I post a message in #foo
+    And I post a reply in #bar
+    And I delete the parent message in #foo
+    Then the parent message in #bar should be "This message was deleted."
+
+  Scenario: User deletes a parent message, then replies to original parent
+    Given I have a simple gateway between #foo and #bar
+    And I post a message in #foo
+    And I post a reply in #bar
+    And I delete the parent message in #foo
+    And I post another reply in #foo
+    Then the final reply should appear in #bar
+
+  Scenario: User deletes a parent message, then replies to relayed parent
+    Given I have a simple gateway between #foo and #bar
+    And I post a message in #foo
+    And I post a reply in #bar
+    And I delete the parent message in #foo
+    And I post another reply in #bar
+    Then the final reply should appear in #foo


### PR DESCRIPTION
I'm sure the deciding to use any specific tool should get more discussion, but just wanted to suggest that perhaps we could start keeping tracking of the scenarios that we know can create issues. Even if we never execute them, we can still use them to write future tests using another framework. Also, we can start asking people who encounter bugs to write scenarios for us, so that we can test later. This is a pretty low bar for participation. No everyone writes golang or tests, but everyone can look at the scenarios and make their own us :)