### PR TITLE
Clean-up TravisCI config and add test coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: go
 go:
     - 1.11.x
+go_import_path: github.com/42wim/matterbridge
 
 # we have everything vendored
 install: true
@@ -9,9 +10,8 @@ git:
   depth: 200
 
 env:
+  global:
     - GOOS=linux GOARCH=amd64
-      #    - GOOS=windows GOARCH=amd64
-      #- GOOS=linux GOARCH=arm
 
 matrix:
   # It's ok if our code fails on unstable development versions of Go.
@@ -25,25 +25,26 @@ notifications:
       email: false
 
 before_script:
+  # Get version info from tags.
   - MY_VERSION=$(git describe --tags)
-#  - GO_FILES=$(find . -iname '*.go' | grep -v /vendor/)  # All the .go files, excluding vendor/
-  - PKGS=$(go list ./... | grep -v /vendor/)             # All the import paths, excluding vendor/
-#  - go get github.com/golang/lint/golint                 # Linter
-#- go get honnef.co/go/tools/cmd/megacheck              # Badass static analyzer/linter
+  # Retrieve the golangci-lint linter binary.
   - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b $GOPATH/bin v1.12.2
+  # Retrieve and prepare CodeClimate's test coverage reporter.
+  - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+  - chmod +x ./cc-test-reporter
+  - ./cc-test-reporter before-build
 
-
-# Anything in before_script: that returns a nonzero exit code will
-# flunk the build and immediately stop. It's sorta like having
-# set -e enabled in bash. 
 script:
-  #- test -z "$(go fmt ./...)"         # Fail if a .go file hasn't been formatted with gofmt
-  - go test -v -race $PKGS            # Run all the tests with the race detector enabled
-  #- go vet $PKGS                      # go vet is the official Go static analyzer
+  # Run the linter.
   - golangci-lint run --enable-all -D lll -D errcheck -D gosec -D maligned -D prealloc -D gocyclo -D gochecknoglobals
-  #- megacheck $PKGS                   # "go vet on steroids" + linter
+  # Run all the tests with the race detector and generate coverage.
+  - go test -v -race -coverprofile c.out ./...
+  # Run the build script to generate the necessary binaries and images.
   - /bin/bash ci/bintray.sh
-  #- golint -set_exit_status $PKGS     # one last linter
+
+after_script:
+  # Upload test coverage to CodeClimate.
+  - ./cc-test-reporter after-build --exit-code ${TRAVIS_TEST_RESULT}
 
 deploy:
   provider: bintray


### PR DESCRIPTION
Doing the necessary to configure test coverage reporting via CodeClimate. The only thing that is missing here is to set the `CC_TEST_REPORTER_ID` env variable in TravisCI as a secret but it can only be retrieved by the repo admin on CodeClimate (@42wim). You can grab the ID from [here](https://codeclimate.com/repos/5bdb7bf561590b026f000d13/settings/test_reporter) (for which I get a permission denied) and add it to the TravisCI setup [here](https://travis-ci.org/42wim/matterbridge/settings).

Have already verified that it works on my fork of the repo and with my own CodeClimate / TravisCI setup.