### PR TITLE
Add wait option for populateUsers/Channels. Fixes #579

### DIFF
--- a/bridge/slack/handlers.go
+++ b/bridge/slack/handlers.go
@@ -75,7 +75,7 @@ func (b *Bslack) handleSlackClient(messages chan *config.Message) {
 			// When we join a channel we update the full list of users as
 			// well as the information for the channel that we joined as this
 			// should now tell that we are a member of it.
-			b.populateUsers()
+			b.populateUsers(false)
 
 			b.channelsMutex.Lock()
 			b.channelsByID[ev.Channel.ID] = &ev.Channel
@@ -83,8 +83,8 @@ func (b *Bslack) handleSlackClient(messages chan *config.Message) {
 			b.channelsMutex.Unlock()
 		case *slack.ConnectedEvent:
 			b.si = ev.Info
-			b.populateChannels()
-			b.populateUsers()
+			b.populateChannels(true)
+			b.populateUsers(true)
 		case *slack.InvalidAuthEvent:
 			b.Log.Fatalf("Invalid Token %#v", ev)
 		case *slack.ConnectionErrorEvent:
@@ -200,7 +200,7 @@ func (b *Bslack) handleMessageEvent(ev *slack.MessageEvent) (*config.Message, er
 func (b *Bslack) handleStatusEvent(ev *slack.MessageEvent, rmsg *config.Message) bool {
 	switch ev.SubType {
 	case sChannelJoined, sMemberJoined:
-		b.populateUsers()
+		b.populateUsers(false)
 		// There's no further processing needed on channel events
 		// so we return 'true'.
 		return true
@@ -208,7 +208,7 @@ func (b *Bslack) handleStatusEvent(ev *slack.MessageEvent, rmsg *config.Message)
 		rmsg.Username = sSystemUser
 		rmsg.Event = config.EventJoinLeave
 	case sChannelTopic, sChannelPurpose:
-		b.populateChannels()
+		b.populateChannels(false)
 		rmsg.Event = config.EventTopicChange
 	case sMessageChanged:
 		rmsg.Text = ev.SubMessage.Text

--- a/bridge/slack/helpers.go
+++ b/bridge/slack/helpers.go
@@ -83,14 +83,17 @@ func (b *Bslack) populateUser(userID string) {
 	b.usersMutex.Unlock()
 }
 
-func (b *Bslack) populateUsers() {
+func (b *Bslack) populateUsers(wait bool) {
 	b.refreshMutex.Lock()
-	if time.Now().Before(b.earliestUserRefresh) || b.refreshInProgress {
+	if !wait && (time.Now().Before(b.earliestUserRefresh) || b.refreshInProgress) {
 		b.Log.Debugf("Not refreshing user list as it was done less than %v ago.",
 			minimumRefreshInterval)
 		b.refreshMutex.Unlock()
 
 		return
+	}
+	for b.refreshInProgress {
+		time.Sleep(time.Second)
 	}
 	b.refreshInProgress = true
 	b.refreshMutex.Unlock()
@@ -127,13 +130,16 @@ func (b *Bslack) populateUsers() {
 	b.refreshInProgress = false
 }
 
-func (b *Bslack) populateChannels() {
+func (b *Bslack) populateChannels(wait bool) {
 	b.refreshMutex.Lock()
-	if time.Now().Before(b.earliestChannelRefresh) || b.refreshInProgress {
+	if !wait && (time.Now().Before(b.earliestChannelRefresh) || b.refreshInProgress) {
 		b.Log.Debugf("Not refreshing channel list as it was done less than %v seconds ago.",
 			minimumRefreshInterval)
 		b.refreshMutex.Unlock()
 		return
+	}
+	for b.refreshInProgress {
+		time.Sleep(time.Second)
 	}
 	b.refreshInProgress = true
 	b.refreshMutex.Unlock()

--- a/bridge/slack/slack.go
+++ b/bridge/slack/slack.go
@@ -160,7 +160,7 @@ func (b *Bslack) JoinChannel(channel config.ChannelInfo) error {
 		return nil
 	}
 
-	b.populateChannels()
+	b.populateChannels(false)
 
 	channelInfo, err := b.getChannel(channel.Name)
 	if err != nil {


### PR DESCRIPTION
When setting wait to true, we wait until the populating isn't in progress anymore.
This is used on startup connections where we really need the initial information
which could take a long time on big servers.