### PR TITLE
Logging rewiring - Import linting

### DIFF
--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -1,10 +1,10 @@
 package bridge
 
 import (
-	"github.com/42wim/matterbridge/bridge/config"
-	log "github.com/sirupsen/logrus"
-
 	"strings"
+
+	"github.com/42wim/matterbridge/bridge/config"
+	"github.com/sirupsen/logrus"
 )
 
 type Bridger interface {
@@ -21,7 +21,7 @@ type Bridge struct {
 	Protocol string
 	Channels map[string]config.ChannelInfo
 	Joined   map[string]bool
-	Log      *log.Entry
+	Log      *logrus.Entry
 	Config   config.Config
 	General  *config.Protocol
 }
@@ -29,7 +29,7 @@ type Bridge struct {
 type Config struct {
 	//	General *config.Protocol
 	Remote chan config.Message
-	Log    *log.Entry
+	Log    *logrus.Entry
 	*Bridge
 }
 

--- a/bridge/config/config.go
+++ b/bridge/config/config.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/fsnotify/fsnotify"
 	prefixed "github.com/matterbridge/logrus-prefixed-formatter"
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 )
 
@@ -197,12 +197,12 @@ type config struct {
 }
 
 func NewConfig(cfgfile string) Config {
-	log.SetFormatter(&prefixed.TextFormatter{PrefixPadding: 13, DisableColors: true, FullTimestamp: false})
-	flog := log.WithFields(log.Fields{"prefix": "config"})
+	logrus.SetFormatter(&prefixed.TextFormatter{PrefixPadding: 13, DisableColors: true, FullTimestamp: false})
+	flog := logrus.WithFields(logrus.Fields{"prefix": "config"})
 	viper.SetConfigFile(cfgfile)
 	input, err := getFileContents(cfgfile)
 	if err != nil {
-		log.Fatal(err)
+		logrus.Fatal(err)
 	}
 	mycfg := newConfigFromString(input)
 	if mycfg.cv.General.MediaDownloadSize == 0 {
@@ -218,7 +218,7 @@ func NewConfig(cfgfile string) Config {
 func getFileContents(filename string) ([]byte, error) {
 	input, err := ioutil.ReadFile(filename)
 	if err != nil {
-		log.Fatal(err)
+		logrus.Fatal(err)
 		return []byte(nil), err
 	}
 	return input, nil
@@ -236,13 +236,13 @@ func newConfigFromString(input []byte) *config {
 	viper.AutomaticEnv()
 	err := viper.ReadConfig(bytes.NewBuffer(input))
 	if err != nil {
-		log.Fatal(err)
+		logrus.Fatal(err)
 	}
 
 	cfg := &BridgeValues{}
 	err = viper.Unmarshal(cfg)
 	if err != nil {
-		log.Fatal(err)
+		logrus.Fatal(err)
 	}
 	return &config{
 		v:  viper.GetViper(),

--- a/bridge/helper/helper.go
+++ b/bridge/helper/helper.go
@@ -11,7 +11,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/42wim/matterbridge/bridge/config"
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 func DownloadFile(url string) (*[]byte, error) {
@@ -97,7 +97,7 @@ func GetAvatar(av map[string]string, userid string, general *config.Protocol) st
 	return ""
 }
 
-func HandleDownloadSize(flog *log.Entry, msg *config.Message, name string, size int64, general *config.Protocol) error {
+func HandleDownloadSize(flog *logrus.Entry, msg *config.Message, name string, size int64, general *config.Protocol) error {
 	// check blacklist here
 	for _, entry := range general.MediaDownloadBlackList {
 		if entry != "" {
@@ -120,7 +120,7 @@ func HandleDownloadSize(flog *log.Entry, msg *config.Message, name string, size 
 	return nil
 }
 
-func HandleDownloadData(flog *log.Entry, msg *config.Message, name, comment, url string, data *[]byte, general *config.Protocol) {
+func HandleDownloadData(flog *logrus.Entry, msg *config.Message, name, comment, url string, data *[]byte, general *config.Protocol) {
 	var avatar bool
 	flog.Debugf("Download OK %#v %#v", name, len(*data))
 	if msg.Event == config.EventAvatarDownload {

--- a/bridge/sshchat/sshchat.go
+++ b/bridge/sshchat/sshchat.go
@@ -9,7 +9,7 @@ import (
 	"github.com/42wim/matterbridge/bridge/config"
 	"github.com/42wim/matterbridge/bridge/helper"
 	"github.com/shazow/ssh-chat/sshd"
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 type Bsshchat struct {
@@ -116,7 +116,7 @@ func (b *Bsshchat) handleSSHChat() error {
 			res := strings.Split(stripPrompt(b.r.Text()), ":")
 			if res[0] == "-> Set theme" {
 				wait = false
-				log.Debugf("mono found, allowing")
+				logrus.Debugf("mono found, allowing")
 				continue
 			}
 			if !wait {

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -9,7 +9,7 @@ import (
 	"github.com/42wim/matterbridge/bridge/config"
 	"github.com/hashicorp/golang-lru"
 	"github.com/peterhellberg/emojilib"
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 type Gateway struct {
@@ -31,14 +31,14 @@ type BrMsgID struct {
 	ChannelID string
 }
 
-var flog *log.Entry
+var flog *logrus.Entry
 
 const (
 	apiProtocol = "api"
 )
 
 func New(cfg config.Gateway, r *Router) *Gateway {
-	flog = log.WithFields(log.Fields{"prefix": "gateway"})
+	flog = logrus.WithFields(logrus.Fields{"prefix": "gateway"})
 	gw := &Gateway{Channels: make(map[string]*config.ChannelInfo), Message: r.Message,
 		Router: r, Bridges: make(map[string]*bridge.Bridge), Config: r.Config}
 	cache, _ := lru.New(5000)
@@ -76,8 +76,8 @@ func (gw *Gateway) AddBridge(cfg *config.Bridge) error {
 		br.Config = gw.Router.Config
 		br.General = &gw.BridgeValues().General
 		// set logging
-		br.Log = log.WithFields(log.Fields{"prefix": "bridge"})
-		brconfig := &bridge.Config{Remote: gw.Message, Log: log.WithFields(log.Fields{"prefix": br.Protocol}), Bridge: br}
+		br.Log = logrus.WithFields(logrus.Fields{"prefix": "bridge"})
+		brconfig := &bridge.Config{Remote: gw.Message, Log: logrus.WithFields(logrus.Fields{"prefix": br.Protocol}), Bridge: br}
 		// add the actual bridger for this protocol to this bridge using the bridgeMap
 		br.Bridger = gw.Router.BridgeMap[br.Protocol](brconfig)
 	}

--- a/gateway/gateway_test.go
+++ b/gateway/gateway_test.go
@@ -3,12 +3,11 @@ package gateway
 import (
 	"fmt"
 	"strconv"
+	"testing"
 
 	"github.com/42wim/matterbridge/bridge/config"
 	"github.com/42wim/matterbridge/gateway/bridgemap"
 	"github.com/stretchr/testify/assert"
-
-	"testing"
 )
 
 var testconfig = []byte(`

--- a/gateway/samechannel/samechannel_test.go
+++ b/gateway/samechannel/samechannel_test.go
@@ -1,10 +1,10 @@
 package samechannelgateway
 
 import (
+	"testing"
+
 	"github.com/42wim/matterbridge/bridge/config"
 	"github.com/stretchr/testify/assert"
-
-	"testing"
 )
 
 const testConfig = `

--- a/matterbridge.go
+++ b/matterbridge.go
@@ -11,7 +11,7 @@ import (
 	"github.com/42wim/matterbridge/gateway/bridgemap"
 	"github.com/google/gops/agent"
 	prefixed "github.com/matterbridge/logrus-prefixed-formatter"
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 var (
@@ -20,8 +20,8 @@ var (
 )
 
 func main() {
-	log.SetFormatter(&prefixed.TextFormatter{PrefixPadding: 13, DisableColors: true, FullTimestamp: true})
-	flog := log.WithFields(log.Fields{"prefix": "main"})
+	logrus.SetFormatter(&prefixed.TextFormatter{PrefixPadding: 13, DisableColors: true, FullTimestamp: true})
+	flog := logrus.WithFields(logrus.Fields{"prefix": "main"})
 	flagConfig := flag.String("conf", "matterbridge.toml", "config file")
 	flagDebug := flag.Bool("debug", false, "enable debug")
 	flagVersion := flag.Bool("version", false, "show version")
@@ -39,9 +39,9 @@ func main() {
 		return
 	}
 	if *flagDebug || os.Getenv("DEBUG") == "1" {
-		log.SetFormatter(&prefixed.TextFormatter{PrefixPadding: 13, DisableColors: true, FullTimestamp: false, ForceFormatting: true})
+		logrus.SetFormatter(&prefixed.TextFormatter{PrefixPadding: 13, DisableColors: true, FullTimestamp: false, ForceFormatting: true})
 		flog.Info("Enabling debug")
-		log.SetLevel(log.DebugLevel)
+		logrus.SetLevel(logrus.DebugLevel)
 	}
 	flog.Printf("Running version %s %s", version, githash)
 	if strings.Contains(version, "-dev") {

--- a/matterclient/channels.go
+++ b/matterclient/channels.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 
 	"github.com/mattermost/mattermost-server/model"
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 // GetChannels returns all channels we're members off
@@ -192,7 +192,7 @@ func (m *MMClient) UpdateChannelHeader(channelId string, header string) { //noli
 	m.log.Debugf("updating channelheader %#v, %#v", channelId, header)
 	_, resp := m.Client.UpdateChannel(channel)
 	if resp.Error != nil {
-		log.Error(resp.Error)
+		logrus.Error(resp.Error)
 	}
 }
 

--- a/matterclient/matterclient.go
+++ b/matterclient/matterclient.go
@@ -12,7 +12,7 @@ import (
 	"github.com/jpillora/backoff"
 	prefixed "github.com/matterbridge/logrus-prefixed-formatter"
 	"github.com/mattermost/mattermost-server/model"
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 type Credentials struct {
@@ -55,7 +55,7 @@ type MMClient struct {
 	User          *model.User
 	Users         map[string]*model.User
 	MessageChan   chan *Message
-	log           *log.Entry
+	log           *logrus.Entry
 	WsClient      *websocket.Conn
 	WsQuit        bool
 	WsAway        bool
@@ -70,23 +70,23 @@ type MMClient struct {
 func New(login, pass, team, server string) *MMClient {
 	cred := &Credentials{Login: login, Pass: pass, Team: team, Server: server}
 	mmclient := &MMClient{Credentials: cred, MessageChan: make(chan *Message, 100), Users: make(map[string]*model.User)}
-	log.SetFormatter(&prefixed.TextFormatter{PrefixPadding: 13, DisableColors: true})
-	mmclient.log = log.WithFields(log.Fields{"prefix": "matterclient"})
+	logrus.SetFormatter(&prefixed.TextFormatter{PrefixPadding: 13, DisableColors: true})
+	mmclient.log = logrus.WithFields(logrus.Fields{"prefix": "matterclient"})
 	mmclient.lruCache, _ = lru.New(500)
 	return mmclient
 }
 
 func (m *MMClient) SetDebugLog() {
-	log.SetFormatter(&prefixed.TextFormatter{PrefixPadding: 13, DisableColors: true, FullTimestamp: false, ForceFormatting: true})
+	logrus.SetFormatter(&prefixed.TextFormatter{PrefixPadding: 13, DisableColors: true, FullTimestamp: false, ForceFormatting: true})
 }
 
 func (m *MMClient) SetLogLevel(level string) {
-	l, err := log.ParseLevel(level)
+	l, err := logrus.ParseLevel(level)
 	if err != nil {
-		log.SetLevel(log.InfoLevel)
+		logrus.SetLevel(logrus.InfoLevel)
 		return
 	}
-	log.SetLevel(l)
+	logrus.SetLevel(l)
 }
 
 func (m *MMClient) Login() error {
@@ -209,7 +209,7 @@ func (m *MMClient) StatusLoop() {
 		}
 		if m.WsConnected {
 			if err := m.checkAlive(); err != nil {
-				log.Errorf("Connection is not alive: %#v", err)
+				logrus.Errorf("Connection is not alive: %#v", err)
 			}
 			select {
 			case <-m.WsPingChan:
@@ -222,7 +222,7 @@ func (m *MMClient) StatusLoop() {
 					m.WsQuit = false
 					err := m.Login()
 					if err != nil {
-						log.Errorf("Login failed: %#v", err)
+						logrus.Errorf("Login failed: %#v", err)
 						break
 					}
 					if m.OnWsConnect != nil {


### PR DESCRIPTION
First of two PRs:

1. (This one) - Linting of imports and removal of import-renaming for `github.com/sirupsen/logrus` to remove potential confusion with native `log` package when reading code.

2. Rewiring of `logrus.Logger` instances throughout the code-base to perform a single instantiation within at the root. This will make it easier to forward logs to non-default destinations (ELK, etc).