### PR TITLE
Fix #668 strip lang in code fences sent to Slack

### DIFF
--- a/bridge/slack/helpers.go
+++ b/bridge/slack/helpers.go
@@ -291,6 +291,7 @@ var (
 	channelRE        = regexp.MustCompile(`<#[a-zA-Z0-9]+\|(.+?)>`)
 	variableRE       = regexp.MustCompile(`<!((?:subteam\^)?[a-zA-Z0-9]+)(?:\|@?(.+?))?>`)
 	urlRE            = regexp.MustCompile(`<(.*?)(\|.*?)?>`)
+	codeFenceRE      = regexp.MustCompile(`(?m)^` + "```" + `\w+$`)
 	topicOrPurposeRE = regexp.MustCompile(`(?s)(@.+) (cleared|set)(?: the)? channel (topic|purpose)(?:: (.*))?`)
 )
 
@@ -351,6 +352,10 @@ func (b *Bslack) replaceURL(text string) string {
 		}
 	}
 	return text
+}
+
+func (b *Bslack) replaceCodeFence(text string) string {
+	return codeFenceRE.ReplaceAllString(text, "```")
 }
 
 func (b *Bslack) handleRateLimit(err error) error {

--- a/bridge/slack/slack.go
+++ b/bridge/slack/slack.go
@@ -188,6 +188,8 @@ func (b *Bslack) Send(msg config.Message) (string, error) {
 		b.Log.Debugf("=> Receiving %#v", msg)
 	}
 
+	msg.Text = b.replaceCodeFence(msg.Text)
+
 	// Make a action /me of the message
 	if msg.Event == config.EventUserAction {
 		msg.Text = "_" + msg.Text + "_"


### PR DESCRIPTION
Just had the chance to implement #668. `handleSlack` appears to be converting Slack messages to the central `config.Message` format, so I hope I've found the right place!