### PR TITLE
Add initial support for getting ChannelMember info of all bridges

### DIFF
--- a/bridge/config/config.go
+++ b/bridge/config/config.go
@@ -14,16 +14,17 @@ import (
 )
 
 const (
-	EventJoinLeave       = "join_leave"
-	EventTopicChange     = "topic_change"
-	EventFailure         = "failure"
-	EventFileFailureSize = "file_failure_size"
-	EventAvatarDownload  = "avatar_download"
-	EventRejoinChannels  = "rejoin_channels"
-	EventUserAction      = "user_action"
-	EventMsgDelete       = "msg_delete"
-	EventAPIConnected    = "api_connected"
-	EventUserTyping      = "user_typing"
+	EventJoinLeave         = "join_leave"
+	EventTopicChange       = "topic_change"
+	EventFailure           = "failure"
+	EventFileFailureSize   = "file_failure_size"
+	EventAvatarDownload    = "avatar_download"
+	EventRejoinChannels    = "rejoin_channels"
+	EventUserAction        = "user_action"
+	EventMsgDelete         = "msg_delete"
+	EventAPIConnected      = "api_connected"
+	EventUserTyping        = "user_typing"
+	EventGetChannelMembers = "get_channel_members"
 )
 
 type Message struct {
@@ -60,6 +61,16 @@ type ChannelInfo struct {
 	SameChannel map[string]bool
 	Options     ChannelOptions
 }
+
+type ChannelMember struct {
+	Username    string
+	Nick        string
+	UserID      string
+	ChannelID   string
+	ChannelName string
+}
+
+type ChannelMembers []ChannelMember
 
 type Protocol struct {
 	AuthCode               string // steam

--- a/bridge/slack/slack.go
+++ b/bridge/slack/slack.go
@@ -37,6 +37,9 @@ type Bslack struct {
 	channelsByName map[string]*slack.Channel
 	channelsMutex  sync.RWMutex
 
+	channelMembers      map[string][]string
+	channelMembersMutex sync.RWMutex
+
 	refreshInProgress      bool
 	earliestChannelRefresh time.Time
 	earliestUserRefresh    time.Time
@@ -265,6 +268,11 @@ func (b *Bslack) sendWebhook(msg config.Message) error {
 }
 
 func (b *Bslack) sendRTM(msg config.Message) (string, error) {
+	// Handle channelmember messages.
+	if handled := b.handleGetChannelMembers(&msg); handled {
+		return "", nil
+	}
+
 	channelInfo, err := b.getChannel(msg.Channel)
 	if err != nil {
 		return "", fmt.Errorf("could not send message: %v", err)

--- a/gateway/handlers.go
+++ b/gateway/handlers.go
@@ -30,6 +30,23 @@ func (r *Router) handleEventFailure(msg *config.Message) {
 	}
 }
 
+// handleEventGetChannelMembers handles channel members
+func (r *Router) handleEventGetChannelMembers(msg *config.Message) {
+	if msg.Event != config.EventGetChannelMembers {
+		return
+	}
+	for _, gw := range r.Gateways {
+		for _, br := range gw.Bridges {
+			if msg.Account == br.Account {
+				cMembers := msg.Extra[config.EventGetChannelMembers][0].(config.ChannelMembers)
+				flog.Debugf("Syncing channelmembers from %s", msg.Account)
+				br.SetChannelMembers(&cMembers)
+				return
+			}
+		}
+	}
+}
+
 // handleEventRejoinChannels handles rejoining of channels.
 func (r *Router) handleEventRejoinChannels(msg *config.Message) {
 	if msg.Event != config.EventRejoinChannels {


### PR DESCRIPTION
Add initial support for getting ChannelMember info of all bridges.

Adds an EventGetChannelMembers event, which gets send every x time to
all bridges. Bridges should respond on this event with a Message
containing ChannelMembers in the EventGetChannelMembers key in the
Extra field.

handleEventGetChannelMembers will handle this Message and sets the
contained ChannelMembers to the Bridge struct.

Necessary for #667 and #191