### PR TITLE
Improve error reporting on failure to join Discord

### DIFF
--- a/bridge/discord/discord.go
+++ b/bridge/discord/discord.go
@@ -2,6 +2,7 @@ package bdiscord
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -49,6 +50,7 @@ func New(cfg *bridge.Config) bridge.Bridger {
 func (b *Bdiscord) Connect() error {
 	var err error
 	var token string
+	var guildFound bool
 	b.Log.Info("Connecting")
 	if b.GetString("WebhookURL") == "" {
 		b.Log.Info("Connecting using token")
@@ -86,12 +88,24 @@ func (b *Bdiscord) Connect() error {
 		if guild.Name == serverName || guild.ID == serverName {
 			b.channels, err = b.c.GuildChannels(guild.ID)
 			b.guildID = guild.ID
+			guildFound = true
 			if err != nil {
 				break
 			}
 		}
 	}
 	b.channelsMutex.Unlock()
+	if !guildFound {
+		msg := fmt.Sprintf("Server \"%s\" not found", b.GetString("Server"))
+		err = errors.New(msg)
+		b.Log.Error(msg)
+		b.Log.Info("Possible values:")
+		for _, guild := range guilds {
+			b.Log.Infof("Server=\"%s\" # Server name", guild.Name)
+			b.Log.Infof("Server=\"%s\" # Server ID", guild.ID)
+		}
+	}
+
 	if err != nil {
 		return err
 	}
@@ -106,7 +120,7 @@ func (b *Bdiscord) Connect() error {
 	defer b.membersMutex.Unlock()
 	members, err := b.c.GuildMembers(b.guildID, "", 1000)
 	if err != nil {
-		b.Log.Error("Error obtaining guild members", err)
+		b.Log.Error("Error obtaining server members: ", err)
 		return err
 	}
 	for _, member := range members {


### PR DESCRIPTION
Fixes #672 - makes it easier to diagnose an incorrect `Server="..."` directive in a Discord configuration.  Also fixes a typo in another error message, and renames "guild" to "server" in related log messages to match Discord's current public interface.

Before:

```
time="2019-01-07T05:33:31Z" level=info msg="Starting bridge: discord.classicpress " prefix=gateway
time="2019-01-07T05:33:31Z" level=info msg=Connecting prefix=discord
time="2019-01-07T05:33:31Z" level=info msg="Connecting using token" prefix=discord
time="2019-01-07T05:33:31Z" level=info msg="Connection succeeded" prefix=discord
time="2019-01-07T05:33:31Z" level=error msg="Error obtaining guild membersHTTP 404 Not Found, {"code": 0, "message": "404: Not Found"}" prefix=discord
time="2019-01-07T05:33:31Z" level=fatal msg="Starting gateway failed: Bridge discord.classicpress failed to start: HTTP 404 Not Found, {"code": 0, "message": "404: Not Found"}" prefix=main
```

Intermediate step (error typo fix):

```diff
-time="2019-01-07T05:33:31Z" level=error msg="Error obtaining guild membersHTTP 404 Not Found, {"code": 0, "message": "404: Not Found"}" prefix=discord
+time="2019-01-07T05:33:31Z" level=error msg="Error obtaining guild members: HTTP 404 Not Found, {"code": 0, "message": "404: Not Found"}" prefix=discord
```

After:

```
time="2019-01-07T05:53:57Z" level=info msg="Starting bridge: discord.classicpress " prefix=gateway
time="2019-01-07T05:53:57Z" level=info msg=Connecting prefix=discord
time="2019-01-07T05:53:57Z" level=info msg="Connecting using token" prefix=discord
time="2019-01-07T05:53:57Z" level=info msg="Connection succeeded" prefix=discord
time="2019-01-07T05:53:58Z" level=error msg="Server "invalid" not found" prefix=discord
time="2019-01-07T05:53:58Z" level=info msg="Possible values:" prefix=discord
time="2019-01-07T05:53:58Z" level=info msg="Server="ClassicPress" # Server name" prefix=discord
time="2019-01-07T05:53:58Z" level=info msg="Server="523286444283002890" # Server ID" prefix=discord
time="2019-01-07T05:53:58Z" level=fatal msg="Starting gateway failed: Bridge discord.classicpress failed to start: Server "invalid" not found" prefix=main
```