### PR TITLE
Discord: Mark edited webhook messages with a pencil icon

### DIFF
--- a/bridge/discord/discord.go
+++ b/bridge/discord/discord.go
@@ -13,7 +13,10 @@ import (
 	"github.com/bwmarrin/discordgo"
 )
 
-const MessageLength = 1950
+const (
+	MessageLength               = 1950
+	webhookPlaceholderMessageID = "-webhook-message-"
+)
 
 type Bdiscord struct {
 	*bridge.Config
@@ -203,7 +206,7 @@ func (b *Bdiscord) Send(msg config.Message) (string, error) {
 			return "", nil
 		}
 
-		if msg.ID == "-webhook-" {
+		if msg.ID == webhookPlaceholderMessageID {
 			// Received an edit for a message that was previously sent via a
 			// webhook.  We can't edit the original message, but we can mark
 			// the new version with a pencil icon.
@@ -225,14 +228,14 @@ func (b *Bdiscord) Send(msg config.Message) (string, error) {
 				AvatarURL: msg.Avatar,
 			})
 		// Replace with real ID after https://github.com/bwmarrin/discordgo/issues/622
-		return "-webhook-", err
+		return webhookPlaceholderMessageID, err
 	}
 
 	b.Log.Debugf("Broadcasting using token (API)")
 
 	// Delete message
 	if msg.Event == config.EventMsgDelete {
-		if msg.ID == "" || msg.ID == "-webhook-" {
+		if msg.ID == "" || msg.ID == webhookPlaceholderMessageID {
 			return "", nil
 		}
 		err := b.c.ChannelMessageDelete(channelID, msg.ID)
@@ -257,7 +260,7 @@ func (b *Bdiscord) Send(msg config.Message) (string, error) {
 	msg.Text = b.replaceUserMentions(msg.Text)
 
 	// Edit message
-	if msg.ID != "" && msg.ID != "-webhook-" {
+	if msg.ID != "" && msg.ID != webhookPlaceholderMessageID {
 		// Note: cannot edit messages made by a webhook.  This should never
 		// happen though, because if we get here then it means we don't have a
 		// usable webhook.

--- a/bridge/discord/discord.go
+++ b/bridge/discord/discord.go
@@ -14,6 +14,7 @@ import (
 )
 
 const (
+	// MessageLength Max message length for a Discord message
 	MessageLength               = 1950
 	webhookPlaceholderMessageID = "-webhook-message-"
 )


### PR DESCRIPTION
When using a webhook to send messages to Discord with [avatar spoofing](https://github.com/42wim/matterbridge/wiki/Section-Discord-(basic)#usernameavatar-spoofing), edited messages are posted twice.  This is because Discord doesn't allow editing a message sent by a webhook.

We can't fix that, but we can make a cosmetic improvement to make it clearer that the second copy of the message is actually an edit of the previous message:

| In (Slack) | Out (Discord) |
|--|--|
| ![2019-01-08t23 02 26-05 00](https://user-images.githubusercontent.com/227022/50876172-c060bc80-1399-11e9-900f-b4e4469dc678.png) | ![2019-01-08t23 02 44-05 00](https://user-images.githubusercontent.com/227022/50876171-c060bc80-1399-11e9-84dc-ce48ebda0df0.png) |

https://github.com/bwmarrin/discordgo/issues/622 will allow further improvements, for example:

- Remove the hack of using `-webhook-` as a placeholder for the ID of the original message on Discord
- Add a :memo: reaction to the original message to make it clearer that it has been edited