### PR TITLE
Slack: Mark edited messages with a pencil icon

### DIFF
--- a/bridge/slack/slack.go
+++ b/bridge/slack/slack.go
@@ -390,6 +390,7 @@ func (b *Bslack) editMessage(msg *config.Message, channelInfo *slack.Channel) (b
 		return false, nil
 	}
 	messageOptions := b.prepareMessageOptions(msg)
+	msg.Text = "[:pencil:] " + msg.Text
 	for {
 		messageOptions = append(messageOptions, slack.MsgOptionText(msg.Text, false))
 		_, _, _, err := b.rtm.UpdateMessage(channelInfo.ID, msg.ID, messageOptions...)


### PR DESCRIPTION
When sending messages to Slack, edited messages are updated silently without the `(edited)` text that appears when a regular user edits a message.

We can't fix that, but we can make a cosmetic improvement to make it clearer that the message was edited:

| In (Discord) | Out (Slack) |
|--|--|
| ![2019-01-08t23 08 21-05 00](https://user-images.githubusercontent.com/227022/50876345-9f4c9b80-139a-11e9-8d91-4f0b2ffa1100.png) | ![2019-01-08t23 08 06-05 00](https://user-images.githubusercontent.com/227022/50876346-9f4c9b80-139a-11e9-9f0b-c689d2182e8e.png) |