### PR TITLE
Allow clients to bridge non-bot Discord users

### DIFF
--- a/bridge/discord/discord.go
+++ b/bridge/discord/discord.go
@@ -58,8 +58,10 @@ func (b *Bdiscord) Connect() error {
 	} else {
 		b.Log.Info("Connecting using webhookurl (for posting) and token")
 	}
-	if !strings.HasPrefix(b.GetString("Token"), "Bot ") {
-		token = "Bot " + b.GetString("Token")
+	if !b.GetBool("NotBot") {
+		if !strings.HasPrefix(b.GetString("Token"), "Bot ") {
+			token = "Bot " + b.GetString("Token")
+		}
 	}
 	b.c, err = discordgo.New(token)
 	if err != nil {


### PR DESCRIPTION
Discord's API allows us to connect using user tokens instead of bot ones. To do this, we simply don't prefix "Bot " to the token when creating a socket.

This change creates a new config value that prevents this from happening automatically. It will not change any existing behavior for current users, as `b.GetBool("NotBot")` will return false if the config entry is not there.