### PR TITLE
Allow zulip bridge to specify topic per channel. Closes #701

### DIFF
--- a/bridge/config/config.go
+++ b/bridge/config/config.go
@@ -146,6 +146,7 @@ type Protocol struct {
 type ChannelOptions struct {
 	Key        string // irc, xmpp
 	WebhookURL string // discord
+	Topic      string // zulip
 }
 
 type Bridge struct {

--- a/matterbridge.toml.sample
+++ b/matterbridge.toml.sample
@@ -1185,6 +1185,8 @@ Server="https://yourserver.zulipchat.com"
 
 #Topic of the messages matterbridge will use
 #OPTIONAL (default "matterbridge")
+#You can specify a specific topic for each channel using [gateway.inout.options]
+#See more information below at the gateway configuration
 Topic="matterbridge"
 
 ## RELOADABLE SETTINGS
@@ -1425,6 +1427,13 @@ enable=true
         #OPTIONAL - webhookurl only works for discord (it needs a different URL for each cahnnel)
         [gateway.inout.options]
         webhookurl="https://discordapp.com/api/webhooks/123456789123456789/C9WPqExYWONPDZabcdef-def1434FGFjstasJX9pYht73y"
+
+    [[gateway.inout]]
+    account="zulip.streamchat"
+    channel="general"
+        #OPTIONAL - topic only works for zulip
+        [gateway.inout.options]
+        topic="topic1"
 
     #API example
     #[[gateway.inout]]


### PR DESCRIPTION
Allows you to specific a topic per channel

```
    [[gateway.inout]]
    account="zulip.streamchat"
    channel="general"
        [gateway.inout.options]
        topic="topic1"
```