### PR TITLE
Support rewriting messages from relaybots using ExtractNicks. Fixes #466

### DIFF
--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -351,6 +351,8 @@ func (gw *Gateway) modifyMessage(msg *config.Message) {
 		msg.Text = re.ReplaceAllString(msg.Text, replace)
 	}
 
+	gw.handleExtractNicks(msg)
+
 	// messages from api have Gateway specified, don't overwrite
 	if msg.Protocol != apiProtocol {
 		msg.Gateway = gw.Name

--- a/gateway/handlers_test.go
+++ b/gateway/handlers_test.go
@@ -1,0 +1,75 @@
+package gateway
+
+import (
+	"github.com/42wim/matterbridge/bridge"
+	"github.com/42wim/matterbridge/bridge/config"
+	"github.com/stretchr/testify/assert"
+
+	"testing"
+)
+
+func TestIgnoreEvent(t *testing.T) {
+	eventTests := map[string]struct {
+		input  string
+		dest   *bridge.Bridge
+		output bool
+	}{
+		"avatar mattermost": {
+			input:  config.EventAvatarDownload,
+			dest:   &bridge.Bridge{Protocol: "mattermost"},
+			output: false,
+		},
+		"avatar slack": {
+			input:  config.EventAvatarDownload,
+			dest:   &bridge.Bridge{Protocol: "slack"},
+			output: true,
+		},
+		"avatar telegram": {
+			input:  config.EventAvatarDownload,
+			dest:   &bridge.Bridge{Protocol: "telegram"},
+			output: false,
+		},
+	}
+	gw := &Gateway{}
+	for testname, testcase := range eventTests {
+		output := gw.ignoreEvent(testcase.input, testcase.dest)
+		assert.Equalf(t, testcase.output, output, "case '%s' failed", testname)
+	}
+
+}
+
+func TestExtractNick(t *testing.T) {
+	eventTests := map[string]struct {
+		search         string
+		extract        string
+		username       string
+		text           string
+		resultUsername string
+		resultText     string
+	}{
+		"test1": {
+			search:         "fromgitter",
+			extract:        "<(.*?)>\\s+",
+			username:       "fromgitter",
+			text:           "<userx> blahblah",
+			resultUsername: "userx",
+			resultText:     "blahblah",
+		},
+		"test2": {
+			search: "<.*?bot>",
+			//extract:        `\((.*?)\)\s+`,
+			extract:        "\\((.*?)\\)\\s+",
+			username:       "<matterbot>",
+			text:           "(userx) blahblah (abc) test",
+			resultUsername: "userx",
+			resultText:     "blahblah (abc) test",
+		},
+	}
+	//	gw := &Gateway{}
+	for testname, testcase := range eventTests {
+		resultUsername, resultText, _ := extractNick(testcase.search, testcase.extract, testcase.username, testcase.text)
+		assert.Equalf(t, testcase.resultUsername, resultUsername, "case '%s' failed", testname)
+		assert.Equalf(t, testcase.resultText, resultText, "case '%s' failed", testname)
+	}
+
+}

--- a/matterbridge.toml.sample
+++ b/matterbridge.toml.sample
@@ -130,6 +130,17 @@ ReplaceMessages=[ ["cat","dog"] ]
 #optional (default empty)
 ReplaceNicks=[ ["user--","user"] ]
 
+#Extractnicks is used to for example rewrite messages from other relaybots
+#See https://github.com/42wim/matterbridge/issues/713 and https://github.com/42wim/matterbridge/issues/466
+#some examples:
+#this replaces a message like "Relaybot: <relayeduser> something interesting" to "relayeduser: something interesting"
+#ExtractNicks=[ [ "Relaybot", "<(.*?)>\\s+" ] ]
+#you can use multiple entries for multiplebots
+#this also replaces a message like "otherbot: (relayeduser) something else" to "relayeduser: something else"
+#ExtractNicks=[ [ "Relaybot", "<(.*?)>\\s+" ],[ "otherbot","\\((.*?)\\)\\s+" ]
+#OPTIONAL (default empty)
+ExtractNicks=[ ["otherbot","<(.*?)>\\s+" ] ]
+
 #extra label that can be used in the RemoteNickFormat
 #optional (default empty)
 Label=""
@@ -225,6 +236,17 @@ ReplaceMessages=[ ["cat","dog"] ]
 #OPTIONAL (default empty)
 ReplaceNicks=[ ["user--","user"] ]
 
+#Extractnicks is used to for example rewrite messages from other relaybots
+#See https://github.com/42wim/matterbridge/issues/713 and https://github.com/42wim/matterbridge/issues/466
+#some examples:
+#this replaces a message like "Relaybot: <relayeduser> something interesting" to "relayeduser: something interesting"
+#ExtractNicks=[ [ "Relaybot", "<(.*?)>\\s+" ] ]
+#you can use multiple entries for multiplebots
+#this also replaces a message like "otherbot: (relayeduser) something else" to "relayeduser: something else"
+#ExtractNicks=[ [ "Relaybot", "<(.*?)>\\s+" ],[ "otherbot","\\((.*?)\\)\\s+" ]
+#OPTIONAL (default empty)
+ExtractNicks=[ ["otherbot","<(.*?)>\\s+" ] ]
+
 #extra label that can be used in the RemoteNickFormat
 #optional (default empty)
 Label=""
@@ -305,6 +327,17 @@ ReplaceMessages=[ ["cat","dog"] ]
 #see replacemessages for syntaxa
 #optional (default empty)
 ReplaceNicks=[ ["user--","user"] ]
+
+#Extractnicks is used to for example rewrite messages from other relaybots
+#See https://github.com/42wim/matterbridge/issues/713 and https://github.com/42wim/matterbridge/issues/466
+#some examples:
+#this replaces a message like "Relaybot: <relayeduser> something interesting" to "relayeduser: something interesting"
+#ExtractNicks=[ [ "Relaybot", "<(.*?)>\\s+" ] ]
+#you can use multiple entries for multiplebots
+#this also replaces a message like "otherbot: (relayeduser) something else" to "relayeduser: something else"
+#ExtractNicks=[ [ "Relaybot", "<(.*?)>\\s+" ],[ "otherbot","\\((.*?)\\)\\s+" ]
+#OPTIONAL (default empty)
+ExtractNicks=[ ["otherbot","<(.*?)>\\s+" ] ]
 
 #extra label that can be used in the RemoteNickFormat
 #optional (default empty)
@@ -447,6 +480,17 @@ ReplaceMessages=[ ["cat","dog"] ]
 #optional (default empty)
 ReplaceNicks=[ ["user--","user"] ]
 
+#Extractnicks is used to for example rewrite messages from other relaybots
+#See https://github.com/42wim/matterbridge/issues/713 and https://github.com/42wim/matterbridge/issues/466
+#some examples:
+#this replaces a message like "Relaybot: <relayeduser> something interesting" to "relayeduser: something interesting"
+#ExtractNicks=[ [ "Relaybot", "<(.*?)>\\s+" ] ]
+#you can use multiple entries for multiplebots
+#this also replaces a message like "otherbot: (relayeduser) something else" to "relayeduser: something else"
+#ExtractNicks=[ [ "Relaybot", "<(.*?)>\\s+" ],[ "otherbot","\\((.*?)\\)\\s+" ]
+#OPTIONAL (default empty)
+ExtractNicks=[ ["otherbot","<(.*?)>\\s+" ] ]
+
 #extra label that can be used in the RemoteNickFormat
 #optional (default empty)
 Label=""
@@ -522,6 +566,17 @@ ReplaceMessages=[ ["cat","dog"] ]
 #see replacemessages for syntaxa
 #optional (default empty)
 ReplaceNicks=[ ["user--","user"] ]
+
+#Extractnicks is used to for example rewrite messages from other relaybots
+#See https://github.com/42wim/matterbridge/issues/713 and https://github.com/42wim/matterbridge/issues/466
+#some examples:
+#this replaces a message like "Relaybot: <relayeduser> something interesting" to "relayeduser: something interesting"
+#ExtractNicks=[ [ "Relaybot", "<(.*?)>\\s+" ] ]
+#you can use multiple entries for multiplebots
+#this also replaces a message like "otherbot: (relayeduser) something else" to "relayeduser: something else"
+#ExtractNicks=[ [ "Relaybot", "<(.*?)>\\s+" ],[ "otherbot","\\((.*?)\\)\\s+" ]
+#OPTIONAL (default empty)
+ExtractNicks=[ ["otherbot","<(.*?)>\\s+" ] ]
 
 #extra label that can be used in the RemoteNickFormat
 #optional (default empty)
@@ -646,6 +701,17 @@ ReplaceMessages=[ ["cat","dog"] ]
 #optional (default empty)
 ReplaceNicks=[ ["user--","user"] ]
 
+#Extractnicks is used to for example rewrite messages from other relaybots
+#See https://github.com/42wim/matterbridge/issues/713 and https://github.com/42wim/matterbridge/issues/466
+#some examples:
+#this replaces a message like "Relaybot: <relayeduser> something interesting" to "relayeduser: something interesting"
+#ExtractNicks=[ [ "Relaybot", "<(.*?)>\\s+" ] ]
+#you can use multiple entries for multiplebots
+#this also replaces a message like "otherbot: (relayeduser) something else" to "relayeduser: something else"
+#ExtractNicks=[ [ "Relaybot", "<(.*?)>\\s+" ],[ "otherbot","\\((.*?)\\)\\s+" ]
+#OPTIONAL (default empty)
+ExtractNicks=[ ["otherbot","<(.*?)>\\s+" ] ]
+
 #extra label that can be used in the RemoteNickFormat
 #optional (default empty)
 Label=""
@@ -764,6 +830,17 @@ ReplaceMessages=[ ["cat","dog"] ]
 #optional (default empty)
 ReplaceNicks=[ ["user--","user"] ]
 
+#Extractnicks is used to for example rewrite messages from other relaybots
+#See https://github.com/42wim/matterbridge/issues/713 and https://github.com/42wim/matterbridge/issues/466
+#some examples:
+#this replaces a message like "Relaybot: <relayeduser> something interesting" to "relayeduser: something interesting"
+#ExtractNicks=[ [ "Relaybot", "<(.*?)>\\s+" ] ]
+#you can use multiple entries for multiplebots
+#this also replaces a message like "otherbot: (relayeduser) something else" to "relayeduser: something else"
+#ExtractNicks=[ [ "Relaybot", "<(.*?)>\\s+" ],[ "otherbot","\\((.*?)\\)\\s+" ]
+#OPTIONAL (default empty)
+ExtractNicks=[ ["otherbot","<(.*?)>\\s+" ] ]
+
 #extra label that can be used in the RemoteNickFormat
 #optional (default empty)
 Label=""
@@ -872,6 +949,17 @@ ReplaceMessages=[ ["cat","dog"] ]
 #see replacemessages for syntaxa
 #optional (default empty)
 ReplaceNicks=[ ["user--","user"] ]
+
+#Extractnicks is used to for example rewrite messages from other relaybots
+#See https://github.com/42wim/matterbridge/issues/713 and https://github.com/42wim/matterbridge/issues/466
+#some examples:
+#this replaces a message like "Relaybot: <relayeduser> something interesting" to "relayeduser: something interesting"
+#ExtractNicks=[ [ "Relaybot", "<(.*?)>\\s+" ] ]
+#you can use multiple entries for multiplebots
+#this also replaces a message like "otherbot: (relayeduser) something else" to "relayeduser: something else"
+#ExtractNicks=[ [ "Relaybot", "<(.*?)>\\s+" ],[ "otherbot","\\((.*?)\\)\\s+" ]
+#OPTIONAL (default empty)
+ExtractNicks=[ ["otherbot","<(.*?)>\\s+" ] ]
 
 #extra label that can be used in the RemoteNickFormat
 #optional (default empty)
@@ -989,6 +1077,17 @@ ReplaceMessages=[ ["cat","dog"] ]
 #optional (default empty)
 ReplaceNicks=[ ["user--","user"] ]
 
+#Extractnicks is used to for example rewrite messages from other relaybots
+#See https://github.com/42wim/matterbridge/issues/713 and https://github.com/42wim/matterbridge/issues/466
+#some examples:
+#this replaces a message like "Relaybot: <relayeduser> something interesting" to "relayeduser: something interesting"
+#ExtractNicks=[ [ "Relaybot", "<(.*?)>\\s+" ] ]
+#you can use multiple entries for multiplebots
+#this also replaces a message like "otherbot: (relayeduser) something else" to "relayeduser: something else"
+#ExtractNicks=[ [ "Relaybot", "<(.*?)>\\s+" ],[ "otherbot","\\((.*?)\\)\\s+" ]
+#OPTIONAL (default empty)
+ExtractNicks=[ ["otherbot","<(.*?)>\\s+" ] ]
+
 #extra label that can be used in the RemoteNickFormat
 #optional (default empty)
 Label=""
@@ -1076,6 +1175,17 @@ ReplaceMessages=[ ["cat","dog"] ]
 #optional (default empty)
 ReplaceNicks=[ ["user--","user"] ]
 
+#Extractnicks is used to for example rewrite messages from other relaybots
+#See https://github.com/42wim/matterbridge/issues/713 and https://github.com/42wim/matterbridge/issues/466
+#some examples:
+#this replaces a message like "Relaybot: <relayeduser> something interesting" to "relayeduser: something interesting"
+#ExtractNicks=[ [ "Relaybot", "<(.*?)>\\s+" ] ]
+#you can use multiple entries for multiplebots
+#this also replaces a message like "otherbot: (relayeduser) something else" to "relayeduser: something else"
+#ExtractNicks=[ [ "Relaybot", "<(.*?)>\\s+" ],[ "otherbot","\\((.*?)\\)\\s+" ]
+#OPTIONAL (default empty)
+ExtractNicks=[ ["otherbot","<(.*?)>\\s+" ] ]
+
 #extra label that can be used in the RemoteNickFormat
 #optional (default empty)
 Label=""
@@ -1156,6 +1266,17 @@ ReplaceMessages=[ ["cat","dog"] ]
 #see replacemessages for syntaxa
 #optional (default empty)
 ReplaceNicks=[ ["user--","user"] ]
+
+#Extractnicks is used to for example rewrite messages from other relaybots
+#See https://github.com/42wim/matterbridge/issues/713 and https://github.com/42wim/matterbridge/issues/466
+#some examples:
+#this replaces a message like "Relaybot: <relayeduser> something interesting" to "relayeduser: something interesting"
+#ExtractNicks=[ [ "Relaybot", "<(.*?)>\\s+" ] ]
+#you can use multiple entries for multiplebots
+#this also replaces a message like "otherbot: (relayeduser) something else" to "relayeduser: something else"
+#ExtractNicks=[ [ "Relaybot", "<(.*?)>\\s+" ],[ "otherbot","\\((.*?)\\)\\s+" ]
+#OPTIONAL (default empty)
+ExtractNicks=[ ["otherbot","<(.*?)>\\s+" ] ]
 
 #extra label that can be used in the RemoteNickFormat
 #optional (default empty)
@@ -1274,6 +1395,17 @@ ReplaceMessages=[ ["cat","dog"] ]
 #see replacemessages for syntaxa
 #optional (default empty)
 ReplaceNicks=[ ["user--","user"] ]
+
+#Extractnicks is used to for example rewrite messages from other relaybots
+#See https://github.com/42wim/matterbridge/issues/713 and https://github.com/42wim/matterbridge/issues/466
+#some examples:
+#this replaces a message like "Relaybot: <relayeduser> something interesting" to "relayeduser: something interesting"
+#ExtractNicks=[ [ "Relaybot", "<(.*?)>\\s+" ] ]
+#you can use multiple entries for multiplebots
+#this also replaces a message like "otherbot: (relayeduser) something else" to "relayeduser: something else"
+#ExtractNicks=[ [ "Relaybot", "<(.*?)>\\s+" ],[ "otherbot","\\((.*?)\\)\\s+" ]
+#OPTIONAL (default empty)
+ExtractNicks=[ ["otherbot","<(.*?)>\\s+" ] ]
 
 #extra label that can be used in the RemoteNickFormat
 #optional (default empty)


### PR DESCRIPTION
some examples:
```
this replaces a message like "Relaybot: <relayeduser> something interesting" to "relayeduser: something interesting"
ExtractNicks=[ [ "Relaybot", "<(.*?)>\\s+" ] ]
you can use multiple entries for multiplebots
this also replaces a message like "otherbot: (relayeduser) something else" to "relayeduser: something else"
ExtractNicks=[ [ "Relaybot", "<(.*?)>\\s+" ],[ "otherbot","\\((.*?)\\)\\s+" ]
OPTIONAL (default empty)
ExtractNicks=[ ["otherbot","<(.*?)>\\s+" ] ]
```