### PR TITLE
Need to specify /topic:mytopic for channel configuration (zulip).

### DIFF
--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -159,6 +159,10 @@ func (gw *Gateway) mapChannelConfig(cfg []config.Bridge, direction string) {
 			gw.logger.Errorf("Mattermost channels do not start with a #: remove the # in %s", br.Channel)
 			os.Exit(1)
 		}
+		if strings.HasPrefix(br.Account, "zulip.") && !strings.Contains(br.Channel, "/topic:") {
+			gw.logger.Errorf("Breaking change, since matterbridge 1.14.0 zulip channels need to specify the topic with channel/topic:mytopic in %s of %s", br.Channel, br.Account)
+			os.Exit(1)
+		}
 		ID := br.Channel + br.Account
 		if _, ok := gw.Channels[ID]; !ok {
 			channel := &config.ChannelInfo{

--- a/matterbridge.toml.sample
+++ b/matterbridge.toml.sample
@@ -1363,12 +1363,6 @@ Login="yourbot-bot@yourserver.zulipchat.com"
 #REQUIRED 
 Server="https://yourserver.zulipchat.com"
 
-#Topic of the messages matterbridge will use
-#OPTIONAL (default "matterbridge")
-#You can specify a specific topic for each channel using [gateway.inout.options]
-#See more information below at the gateway configuration
-Topic="matterbridge"
-
 ## RELOADABLE SETTINGS
 ## Settings below can be reloaded by editing the file
 
@@ -1608,7 +1602,7 @@ enable=true
     #              if you specify an empty string bridge will list all the possibilities
     #            - "Group Name" if you specify a group name the bridge will hint its JID to specify
     #              as group names might change in time and contain weird emoticons
-    # zulip      - stream (without the #)
+    # zulip      - stream/topic:topicname (without the #)
     #                  
     # REQUIRED
     channel="#testing"
@@ -1650,10 +1644,7 @@ enable=true
 
     [[gateway.inout]]
     account="zulip.streamchat"
-    channel="general"
-        #OPTIONAL - topic only works for zulip
-        [gateway.inout.options]
-        topic="topic1"
+    channel="general/topic:mytopic"
 
     #API example
     #[[gateway.inout]]


### PR DESCRIPTION
Breaking change for zulip channel configuration.

For zulip the channel configuration will now need to specify also
the topic with /topic:yourtopic.

Example:
[[gateway.inout]]
account="zulip.streamchat"
channel="general/topic:mytopic"

This fixes the incorrect PR #701 which didn't work with multiple
gateways.