### PR TITLE
Do not send duplicate messages (rocketchat). Fixes #745

### DIFF
--- a/bridge/rocketchat/handlers.go
+++ b/bridge/rocketchat/handlers.go
@@ -40,6 +40,11 @@ func (b *Brocketchat) handleRocketHook(messages chan *config.Message) {
 
 func (b *Brocketchat) handleRocketClient(messages chan *config.Message) {
 	for message := range b.messageChan {
+		// skip messages with same ID, apparently messages get duplicated for an unknown reason
+		if _, ok := b.cache.Get(message.ID); ok {
+			continue
+		}
+		b.cache.Add(message.ID, true)
 		b.Log.Debugf("message %#v", message)
 		m := message
 		if b.skipMessage(&m) {


### PR DESCRIPTION
For an unknown reason we get duplicate messages (from the same channel)
using the realtime API when we have > 1 channel subscribed on.
Solution for now is caching the message ID in a LRU cache and ignoring
the duplicates.

This should be reviewed when we have actual editing support from the
realtime API