### PR TITLE
Implement Rocket.Chat attachments handling

### DIFF
--- a/bridge/helper/helper.go
+++ b/bridge/helper/helper.go
@@ -46,6 +46,29 @@ func DownloadFileAuth(url string, auth string) (*[]byte, error) {
 	return &data, nil
 }
 
+func DownloadFileAuthRocket(url string, token string, userId string) (*[]byte, error) {
+	var buf bytes.Buffer
+	client := &http.Client{
+		Timeout: time.Second * 5,
+	}
+	req, err := http.NewRequest("GET", url, nil)
+
+	req.Header.Add("X-Auth-Token", token)
+	req.Header.Add("X-User-Id", userId)
+
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	io.Copy(&buf, resp.Body)
+	data := buf.Bytes()
+	return &data, nil
+}
+
 // GetSubLines splits messages in newline-delimited lines. If maxLineLength is
 // specified as non-zero GetSubLines will also clip long lines to the maximum
 // length and insert a warning marker that the line was clipped.

--- a/bridge/rocketchat/handlers.go
+++ b/bridge/rocketchat/handlers.go
@@ -88,7 +88,7 @@ func (b *Brocketchat) handleAttachments(message *models.Message, rmsg *config.Me
 
 	// Save the attachments, so that we can send them to other slack (compatible) bridges.
 	if len(message.Attachments) > 0 {
-		rmsg.Extra["rocket_attachments"] = append(rmsg.Extra["rocket_attachments"], message.Attachments)
+		rmsg.Extra["rocketchat_attachments"] = append(rmsg.Extra["rocketchat_attachments"], message.Attachments)
 	}
 
 	// If we have files attached, download them (in memory) and put a pointer to it in msg.Extra.

--- a/bridge/rocketchat/helpers.go
+++ b/bridge/rocketchat/helpers.go
@@ -113,7 +113,9 @@ func (b *Brocketchat) uploadFile(fi *config.FileInfo, channel string) error {
 	}
 	sp := strings.Split(fi.Name, ".")
 	mtype := mime.TypeByExtension("." + sp[len(sp)-1])
+	//Supports only images and video for now
 	if !strings.Contains(mtype, "image") && !strings.Contains(mtype, "video") {
+		b.Log.Infof("Attachment is not supported.")
 		return nil
 	}
 	if err := fb.WriteFile("file", fi.Name, mtype, *fi.Data); err != nil {

--- a/vendor/github.com/matterbridge/Rocket.Chat.Go.SDK/models/message.go
+++ b/vendor/github.com/matterbridge/Rocket.Chat.Go.SDK/models/message.go
@@ -16,6 +16,9 @@ type Message struct {
 
 	Mentions []User `json:"mentions,omitempty"`
 	User     *User  `json:"u,omitempty"`
+
+	Attachments []Attachment `json:"attachments,omitempty"`
+
 	PostMessage
 
 	// Bot         interface{}  `json:"bot"`
@@ -55,7 +58,7 @@ type Attachment struct {
 
 	Title             string `json:"title,omitempty"`
 	TitleLink         string `json:"title_link,omitempty"`
-	TitleLinkDownload string `json:"title_link_download,omitempty"`
+	TitleLinkDownload bool `json:"title_link_download,omitempty"`
 
 	ImageURL string `json:"image_url,omitempty"`
 


### PR DESCRIPTION
I have implemented working version of rocket.chat attachments and tested it with Rocket.chat -> Slack.
TODO: 
- [ ] Generify DownloadFileAuth
- [ ] Remove unnecessary dependencies from handlers
- [x] do we actually need "rocket_attachments"?
- [x] More caching options ?
- [x] More checks if file is ok ?
- [ ] Even more checks if file is ok and better handling if not
- [x] Actually use cache ? is it even  necessary ?
- [ ] Think more about texts of attachment

If anyone has any worthy opinion please share, thanks.
