### PR TITLE
Force Slack link unfurling

### DIFF
--- a/bridge/slack/slack.go
+++ b/bridge/slack/slack.go
@@ -424,7 +424,11 @@ func (b *Bslack) postMessage(msg *config.Message, channelInfo *slack.Channel) (s
 		return "", nil
 	}
 	messageOptions := b.prepareMessageOptions(msg)
-	messageOptions = append(messageOptions, slack.MsgOptionText(msg.Text, false))
+	messageOptions = append(
+		messageOptions,
+		slack.MsgOptionText(msg.Text, false),
+		slack.MsgOptionEnableLinkUnfurl(),
+	)
 	for {
 		_, id, err := b.rtm.PostMessage(channelInfo.ID, messageOptions...)
 		if err == nil {


### PR DESCRIPTION
By default, when sending messages via the `chat.postMessage` API, Slack does not unfurl text-based links (most web pages) but does unfurl media. We should force the behaviour to also unfurl normal web pages.

Reference: https://api.slack.com/docs/message-link-unfurling#classic_unfurling

Fixes #699.