### PR TITLE
CI fixes and improvements

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -105,10 +105,6 @@ linters-settings:
     # with golangci-lint call it on a directory with the changed file.
     check-exported: false
   unparam:
-    # call graph construction algorithm (cha, rta). In general, use cha for libraries,
-    # and rta for programs with main packages. Default is cha.
-    algo: rta
-
     # Inspect exported functions, default is false. Set to true if no external program/library imports your code.
     # XXX: if you enable this setting, unparam will report a lot of false-positives in text editors:
     # if it's called for subdir of a project it can't find external interfaces. All text editor integrations

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -7,7 +7,7 @@ run:
   # concurrency: 4
 
   # timeout for analysis, e.g. 30s, 5m, default is 1m
-  deadline: 1m
+  deadline: 2m
 
   # exit code when at least one issue was found, default is 1
   issues-exit-code: 1

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
 language: go
-go:
-    - 1.12.x
 go_import_path: github.com/42wim/matterbridge
 
 # we have everything vendored
@@ -9,67 +7,65 @@ install: true
 git:
   depth: 200
 
-env:
-  global:
-    - GOOS=linux GOARCH=amd64
-    - GO111MODULE=on
-    - GOLANGCI_VERSION="v1.15.0"
-
-matrix:
-  # It's ok if our code fails on unstable development versions of Go.
-  allow_failures:
-    - go: tip
-  # Don't wait for tip tests to finish. Mark the test run green if the
-  # tests pass on the stable versions of Go.
-  fast_finish: true
+branches:
+  only:
+  - master
 
 notifications:
-      email: false
+  email: false
+
+env:
+  global:
+  - GOOS=linux GOARCH=amd64
+  - GO111MODULE=on
+  - GOLANGCI_VERSION="v1.15.0"
+
+matrix:
+  include:
+  - go: 1.11.x
+    env: GO111MODULE=off
+  - go: 1.11.x
+    env: GO111MODULE=on
+  - go: 1.12.x
+    env: GO111MODULE=on
 
 before_script:
   # Get version info from tags.
-  - MY_VERSION="$(git describe --tags)"
+- MY_VERSION="$(git describe --tags)"
   # Retrieve the golangci-lint linter binary.
-  - curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b ${GOPATH}/bin ${GOLANGCI_VERSION}
+- curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b ${GOPATH}/bin ${GOLANGCI_VERSION}
   # Retrieve and prepare CodeClimate's test coverage reporter.
-  - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
-  - chmod +x ./cc-test-reporter
-  - ./cc-test-reporter before-build
+- curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+- chmod +x ./cc-test-reporter
+- ./cc-test-reporter before-build
 
 script:
   # Ensure that the module files are being kept correctly and that vendored dependencies are up-to-date.
-  - go mod tidy
-  - go mod vendor
-  - git diff --exit-code --quiet || (echo "Please run 'go mod tidy' to clean up the 'go.mod' and 'go.sum' files."; false)
+- go mod tidy
+- go mod vendor
+- git diff --exit-code --quiet || (echo "Please run 'go mod tidy' to clean up the 'go.mod' and 'go.sum' files."; false)
 
   # Run the linter.
-  - golangci-lint run
+- golangci-lint run
 
   # Run all the tests with the race detector and generate coverage.
-  - go test -v -race -coverprofile c.out ./...
-
-  # Run the build script to generate the necessary binaries and images.
-  - /bin/bash ci/bintray.sh
+- go test -v -race -coverprofile c.out ./...
 
 after_script:
   # Upload test coverage to CodeClimate.
-  - ./cc-test-reporter after-build --exit-code ${TRAVIS_TEST_RESULT}
-
-branches:
-  only:
-    - master
+- ./cc-test-reporter after-build --exit-code ${TRAVIS_TEST_RESULT}
 
 deploy:
   on:
-     all_branches: true
-  provider: bintray
-  on:
     all_branches: true
+    condition: env(TRAVIS_GO_VERSION) = 1.12.x
+  before_deploy:
+    # Run the build script to generate the necessary binaries and images.
+  - /bin/bash ci/bintray.sh
+  provider: bintray
   edge:
     branch: v1.8.47
   file: ci/deploy.json
   user: 42wim
-  on:
-     all_branches: true
   key:
-     secure: "CeXXe6JOmt7HYR81MdWLua0ltQHhDdkIeRGBFbgd7hkb1wi8eF9DgpAcQrTso8NIlHNZmSAP46uhFgsRvkuezzX0ygalZ7DCJyAyn3sAMEh+UQSHV1WGThRehTtidqRGjetzsIGSwdrJOWil+XTfbO1Z8DGzfakhSuAZka8CM4BAoe3YeP9rYK8h+84x0GHfczvsLtXZ3mWLvQuwe4pK6+ItBCUg0ae7O7ZUpWHy0xQQkkWztY/6RAzXfaG7DuGjIw+20fhx3WOXRNpHCtZ6Bc3qERCpk0s1HhlQWlrN9wDaFTBWYwlvSnNgvxxMbNXJ6RrRJ0l0bA7FUswYwyroxhzrGLdzWDg8dHaQkypocngdalfhpsnoO9j3ApJhomUFJ3UoEq5nOGRUrKn8MPi+dP0zE4kNQ3e4VNa1ufNrvfpWolMg3xh8OXuhQdD5wIM5zFAbRJLqWSCVAjPq4DDPecmvXBOlIial7oa312lN5qnBnUjvAcxszZ+FUyDHT1Grxzna4tMwxY9obPzZUzm7359AOCCwIQFVB8GLqD2nwIstcXS0zGRz+fhviPipHuBa02q5bGUZwmkvrSNab0s8Jo7pCrel2Rz3nWPKaiCfq2WjbW1CLheSMkOQrjsdUd1hhbqNWFPUjJPInTc77NAKCfm5runv5uyowRLh4NNd0sI="
+    secure: "CeXXe6JOmt7HYR81MdWLua0ltQHhDdkIeRGBFbgd7hkb1wi8eF9DgpAcQrTso8NIlHNZmSAP46uhFgsRvkuezzX0ygalZ7DCJyAyn3sAMEh+UQSHV1WGThRehTtidqRGjetzsIGSwdrJOWil+XTfbO1Z8DGzfakhSuAZka8CM4BAoe3YeP9rYK8h+84x0GHfczvsLtXZ3mWLvQuwe4pK6+ItBCUg0ae7O7ZUpWHy0xQQkkWztY/6RAzXfaG7DuGjIw+20fhx3WOXRNpHCtZ6Bc3qERCpk0s1HhlQWlrN9wDaFTBWYwlvSnNgvxxMbNXJ6RrRJ0l0bA7FUswYwyroxhzrGLdzWDg8dHaQkypocngdalfhpsnoO9j3ApJhomUFJ3UoEq5nOGRUrKn8MPi+dP0zE4kNQ3e4VNa1ufNrvfpWolMg3xh8OXuhQdD5wIM5zFAbRJLqWSCVAjPq4DDPecmvXBOlIial7oa312lN5qnBnUjvAcxszZ+FUyDHT1Grxzna4tMwxY9obPzZUzm7359AOCCwIQFVB8GLqD2nwIstcXS0zGRz+fhviPipHuBa02q5bGUZwmkvrSNab0s8Jo7pCrel2Rz3nWPKaiCfq2WjbW1CLheSMkOQrjsdUd1hhbqNWFPUjJPInTc77NAKCfm5runv5uyowRLh4NNd0sI="

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ env:
   global:
     - GOOS=linux GOARCH=amd64
     - GO111MODULE=on
-    - GOLANGCI_VERSION="v1.14.0"
+    - GOLANGCI_VERSION="v1.15.0"
 
 matrix:
   # It's ok if our code fails on unstable development versions of Go.

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,64 +1,48 @@
 language: go
 go_import_path: github.com/42wim/matterbridge
 
-# we have everything vendored
+# We have everything vendored so this helps TravisCI not run `go get ...`.
 install: true
 
 git:
   depth: 200
 
+notifications:
+  email: false
+
 branches:
   only:
   - master
 
-notifications:
-  email: false
-
-env:
-  global:
-  - GOOS=linux GOARCH=amd64
-  - GO111MODULE=on
-  - GOLANGCI_VERSION="v1.15.0"
-
-matrix:
+jobs:
   include:
-  - go: 1.11.x
-    env: GO111MODULE=off
-  - go: 1.11.x
-    env: GO111MODULE=on
-  - go: 1.12.x
-    env: GO111MODULE=on
-
-before_script:
-  # Get version info from tags.
-- MY_VERSION="$(git describe --tags)"
-  # Retrieve the golangci-lint linter binary.
-- curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b ${GOPATH}/bin ${GOLANGCI_VERSION}
-  # Retrieve and prepare CodeClimate's test coverage reporter.
-- curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
-- chmod +x ./cc-test-reporter
-- ./cc-test-reporter before-build
-
-script:
-  # Ensure that the module files are being kept correctly and that vendored dependencies are up-to-date.
-- go mod tidy
-- go mod vendor
-- git diff --exit-code --quiet || (echo "Please run 'go mod tidy' to clean up the 'go.mod' and 'go.sum' files."; false)
-
-  # Run the linter.
-- golangci-lint run
-
-  # Run all the tests with the race detector and generate coverage.
-- go test -v -race -coverprofile c.out ./...
-
-after_script:
-  # Upload test coverage to CodeClimate.
-- ./cc-test-reporter after-build --exit-code ${TRAVIS_TEST_RESULT}
+  - stage: lint
+    # Run linting in one Go environment only.
+    script: ./ci/lint.sh
+    go: 1.12.x
+    env:
+    - GO111MODULE=on
+    - GOLANGCI_VERSION="v1.15.0"
+  - stage: test
+    # Run tests in a combination of Go environments.
+    script: ./ci/test.sh
+    go: 1.11.x
+    env:
+    - GO111MODULE=off
+  - script: ./ci/test.sh
+    go: 1.11.x
+    env:
+    - GO111MODULE=on
+  - script: ./ci/test.sh
+    go: 1.12.x
+    env:
+    - GO111MODULE=on
+    - REPORT_COVERAGE=1
 
 deploy:
   on:
     all_branches: true
-    condition: env(TRAVIS_GO_VERSION) = 1.12.x
+    condition: env(TRAVIS_GO_VERSION) = 1.12.x AND env(GO111MODULE) = on
   before_deploy:
     # Run the build script to generate the necessary binaries and images.
   - /bin/bash ci/bintray.sh

--- a/ci/bintray.sh
+++ b/ci/bintray.sh
@@ -1,5 +1,4 @@
-#!/bin/bash
-
+#!/usr/bin/env bash
 set -u -e -x -o pipefail
 
 go version | grep go1.12 || exit

--- a/ci/bintray.sh
+++ b/ci/bintray.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
-go version | grep go1.11 || exit
+
+set -u -e -x -o pipefail
+
+go version | grep go1.12 || exit
+
 VERSION=$(git describe --tags)
 mkdir ci/binaries
 GOOS=windows GOARCH=amd64 go build -ldflags "-s -w -X main.githash=$(git log --pretty=format:'%h' -n 1)" -o ci/binaries/matterbridge-$VERSION-windows-amd64.exe

--- a/ci/lint.sh
+++ b/ci/lint.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -u -e -x -o pipefail
+
+if [[ -n "${GOLANGCI_VERSION-}" ]]; then
+  # Retrieve the golangci-lint linter binary.
+  curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b ${GOPATH}/bin ${GOLANGCI_VERSION}
+fi
+
+# Run the linter.
+golangci-lint run
+
+if [[ "${GO111MODULE-off}" == "on" ]]; then
+  # If Go modules are active then check that dependencies are correctly maintained.
+  go mod tidy
+  go mod vendor
+  git diff --exit-code --quiet || (echo "Please run 'go mod tidy' to clean up the 'go.mod' and 'go.sum' files."; false)
+fi

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -u -e -x -o pipefail
+
+if [[ -n "${REPORT_COVERAGE+cover}" ]]; then
+  # Retrieve and prepare CodeClimate's test coverage reporter.
+  curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+  chmod +x ./cc-test-reporter
+  ./cc-test-reporter before-build
+fi
+
+# Run all the tests with the race detector and generate coverage.
+go test -v -race -coverprofile c.out ./...
+
+if [[ -n "${REPORT_COVERAGE+cover}" && "${TRAVIS_SECURE_ENV_VARS}" == "true" ]]; then
+  # Upload test coverage to CodeClimate.
+  ./cc-test-reporter after-build
+fi


### PR DESCRIPTION
Multiple small pieces in this PR:
- Fixing the CI builds as it was broken due to the recent update of TravisCI config to Go 1.12.x
- Moving around CI steps to push them into CI scripts (that can be run locally) and use a build matrix to test in different environments.
- The `algo` parameter for the `unparam` linter has been removed and we
should thus no longer specify it in our `.golangci.yaml`. Also, bumping the GolangCI-lint
version to the latest available minor release.
   See:
   - mvdan/unparam@e6a6d1c51b6f03ac1a9d120f1ea07bc3a3f0e0b9
   - golangci/golangci-lint#367