### PR TITLE
Add tengo support to RemoteNickFormat

### DIFF
--- a/bridge/config/config.go
+++ b/bridge/config/config.go
@@ -166,6 +166,11 @@ type Gateway struct {
 	InOut  []Bridge
 }
 
+type Tengo struct {
+	Message          string
+	RemoteNickFormat string
+}
+
 type SameChannelGateway struct {
 	Name     string
 	Enable   bool
@@ -190,6 +195,7 @@ type BridgeValues struct {
 	WhatsApp           map[string]Protocol // TODO is this struct used? Search for "SlackLegacy" for example didn't return any results
 	Zulip              map[string]Protocol
 	General            Protocol
+	Tengo              Tengo
 	Gateway            []Gateway
 	SameChannelGateway []SameChannelGateway
 }

--- a/contrib/remotenickformat.tengo
+++ b/contrib/remotenickformat.tengo
@@ -1,0 +1,9 @@
+/*
+This script will return the current time in kitchen format if the protocol (of the remote bridge) isn't irc
+See https://github.com/d5/tengo/blob/master/docs/stdlib-times.md
+This result can be used in {TENGO} in RemoteNickFormat
+*/
+times := import("times")
+if protocol != "irc" {
+   result=times.time_format(times.now(),times.format_kitchen)
+}

--- a/matterbridge.toml.sample
+++ b/matterbridge.toml.sample
@@ -1480,6 +1480,7 @@ RemoteNickFormat="{NICK}"
 #The string "{PROTOCOL}" (case sensitive) will be replaced by the protocol used by the bridge
 #The string "{GATEWAY}" (case sensitive) will be replaced by the origin gateway name that is replicating the message.
 #The string "{CHANNEL}" (case sensitive) will be replaced by the origin channel name used by the bridge
+#The string "{TENGO}" (case sensitive) will be replaced by the output of the RemoteNickFormat script under [tengo]
 #OPTIONAL (default empty)
 RemoteNickFormat="[{PROTOCOL}] <{NICK}> "
 
@@ -1551,6 +1552,47 @@ IgnoreFailureOnStart=false
 #https://github.com/d5/tengo/blob/master/docs/stdlib.md
 #OPTIONAL (default empty)
 TengoModifyMessage="example.tengo"
+
+###################################################################
+#Tengo configuration
+###################################################################
+#More information about tengo on: https://github.com/d5/tengo/blob/master/docs/tutorial.md and
+#https://github.com/d5/tengo/blob/master/docs/stdlib.md
+
+[tengo]
+#Message allows you to specify the location of a tengo (https://github.com/d5/tengo/) script.
+#This script will receive every incoming message and can be used to modify the Username and the Text of that message.
+#The script will have the following global variables:
+#to modify: msgUsername and msgText
+#to read: msgChannel and msgAccount
+#
+#The script is reloaded on every message, so you can modify the script on the fly.
+#
+#Example script can be found in https://github.com/42wim/matterbridge/tree/master/gateway/bench.tengo
+#and https://github.com/42wim/matterbridge/tree/master/contrib/example.tengo
+#
+#The example below will check if the text contains blah and if so, it'll replace the text and the username of that message.
+#text := import("text")
+#if text.re_match("blah",msgText) {
+#    msgText="replaced by this"
+#    msgUsername="fakeuser"
+#}
+#OPTIONAL (default empty)
+Message="example.tengo"
+
+#RemoteNickFormat allows you to specify the location of a tengo (https://github.com/d5/tengo/) script.
+#The script will have the following global variables:
+#to modify: result
+#to read: channel, bridge, gateway, protocol, nick
+#
+#The result will be set in {TENGO} in the RemoteNickFormat key of every bridge where {TENGO} is specified
+#
+#The script is reloaded on every message, so you can modify the script on the fly.
+#
+#Example script can be found in https://github.com/42wim/matterbridge/tree/master/contrib/remotenickformat.tengo
+#
+#OPTIONAL (default empty)
+RemoteNickFormat="remotenickformat.tengo"
 
 ###################################################################
 #Gateway configuration


### PR DESCRIPTION
This commit add support for using the result of a tengo script in RemoteNickFormat using {TENGO}
Also adds a new toml table [tengo] with key RemoteNickFormat and value location of the script.
This also moves the TengoModifyMessage from [general] to Message in [tengo]

Documentation:

RemoteNickFormat allows you to specify the location of a tengo (https://github.com/d5/tengo/) script.
The script will have the following global variables:
to modify: result
to read: channel, bridge, gateway, protocol, nick

The result will be set in {TENGO} in the RemoteNickFormat key of every bridge where {TENGO} is specified
The script is reloaded on every message, so you can modify the script on the fly.
Example script can be found in https://github.com/42wim/matterbridge/tree/master/contrib/remotenickformat.tengo

[tengo]
RemoteNickFormat="remotenickformat.tengo"