### PR TITLE
Add remotenickformat-zerowidth.tengo to contrib

### DIFF
--- a/contrib/remotenickformat-zerowidth.tengo
+++ b/contrib/remotenickformat-zerowidth.tengo
@@ -1,0 +1,16 @@
+/*
+This script will return the nick except with multi-character usernames
+containing a zero-width space between the first and second character letter.
+
+Single character usernames will be left untouched.
+
+This is useful to prevent remote users from nickalerting
+IRC users of the same name when the remote user speaks.
+
+This result can be used in {TENGO} in RemoteNickFormat.
+*/
+
+result = nick
+if len(nick) > 1 {
+    result = string(nick[0]) + "​" + nick[1:]
+}


### PR DESCRIPTION
Example situation:

- User `qaisjp` is on both Discord and IRC with the same username
- Whenever `@qaisjp` (Discord) speaks, a message is sent to IRC like `<qaisjp> message`.
- Because the IRC username is in that string `qaisjp` receives a notification on IRC which can be very annoying.

This pull request includes a zero-width space between the first and second character of `qaisjp` so that IRC clients are not nickalerted by usernames.

This is currently in use and currently works. This is also a common solution for many bridges.