### PR TITLE
Add verbose IRC joins/parts (ident@host)

### DIFF
--- a/bridge/config/config.go
+++ b/bridge/config/config.go
@@ -141,7 +141,7 @@ type Protocol struct {
 	UseFirstName           bool       // telegram
 	UseUserName            bool       // discord
 	UseInsecureURL         bool       // telegram
-	VerboseJoinPart	       bool       // IRC
+	VerboseJoinPart        bool       // IRC
 	WebhookBindAddress     string     // mattermost, slack
 	WebhookURL             string     // mattermost, slack
 }

--- a/bridge/config/config.go
+++ b/bridge/config/config.go
@@ -120,7 +120,7 @@ type Protocol struct {
 	ReplaceMessages        [][]string // all protocols
 	ReplaceNicks           [][]string // all protocols
 	RemoteNickFormat       string     // all protocols
-	RunCommands            []string   // irc
+	RunCommands            []string   // IRC
 	Server                 string     // IRC,mattermost,XMPP,discord
 	ShowJoinPart           bool       // all protocols
 	ShowTopicChange        bool       // slack
@@ -141,6 +141,7 @@ type Protocol struct {
 	UseFirstName           bool       // telegram
 	UseUserName            bool       // discord
 	UseInsecureURL         bool       // telegram
+	VerboseJoinPart	       bool       // IRC
 	WebhookBindAddress     string     // mattermost, slack
 	WebhookURL             string     // mattermost, slack
 }

--- a/bridge/irc/handlers.go
+++ b/bridge/irc/handlers.go
@@ -91,8 +91,16 @@ func (b *Birc) handleJoinPart(client *girc.Client, event girc.Event) {
 		if b.GetBool("nosendjoinpart") {
 			return
 		}
-		b.Log.Debugf("<= Sending JOIN_LEAVE event from %s to gateway", b.Account)
-		msg := config.Message{Username: "system", Text: event.Source.Name + " " + strings.ToLower(event.Command) + "s", Channel: channel, Account: b.Account, Event: config.EventJoinLeave}
+		
+		msg := config.Message{}
+		if b.GetBool("verbosejoinpart") {
+			b.Log.Debugf("<= Sending verbose JOIN_LEAVE event from %s to gateway", b.Account)
+			msg = config.Message{Username: "system", Text: event.Source.Name + " (" + event.Source.Ident + "@" + event.Source.Host + ") " + strings.ToLower(event.Command) + "s", Channel: channel, Account: b.Account, Event: config.EventJoinLeave}
+		} else {
+			b.Log.Debugf("<= Sending JOIN_LEAVE event from %s to gateway", b.Account)
+			msg = config.Message{Username: "system", Text: event.Source.Name + " " + strings.ToLower(event.Command) + "s", Channel: channel, Account: b.Account, Event: config.EventJoinLeave}
+		}
+
 		b.Log.Debugf("<= Message is %#v", msg)
 		b.Remote <- msg
 		return

--- a/bridge/irc/handlers.go
+++ b/bridge/irc/handlers.go
@@ -91,15 +91,13 @@ func (b *Birc) handleJoinPart(client *girc.Client, event girc.Event) {
 		if b.GetBool("nosendjoinpart") {
 			return
 		}
-		msg := config.Message{}
+		msg := config.Message{Username: "system", Text: event.Source.Name + " " + strings.ToLower(event.Command) + "s", Channel: channel, Account: b.Account, Event: config.EventJoinLeave}
 		if b.GetBool("verbosejoinpart") {
 			b.Log.Debugf("<= Sending verbose JOIN_LEAVE event from %s to gateway", b.Account)
 			msg = config.Message{Username: "system", Text: event.Source.Name + " (" + event.Source.Ident + "@" + event.Source.Host + ") " + strings.ToLower(event.Command) + "s", Channel: channel, Account: b.Account, Event: config.EventJoinLeave}
 		} else {
 			b.Log.Debugf("<= Sending JOIN_LEAVE event from %s to gateway", b.Account)
-			msg = config.Message{Username: "system", Text: event.Source.Name + " " + strings.ToLower(event.Command) + "s", Channel: channel, Account: b.Account, Event: config.EventJoinLeave}
 		}
-
 		b.Log.Debugf("<= Message is %#v", msg)
 		b.Remote <- msg
 		return

--- a/bridge/irc/handlers.go
+++ b/bridge/irc/handlers.go
@@ -91,7 +91,6 @@ func (b *Birc) handleJoinPart(client *girc.Client, event girc.Event) {
 		if b.GetBool("nosendjoinpart") {
 			return
 		}
-		
 		msg := config.Message{}
 		if b.GetBool("verbosejoinpart") {
 			b.Log.Debugf("<= Sending verbose JOIN_LEAVE event from %s to gateway", b.Account)

--- a/matterbridge.toml.sample
+++ b/matterbridge.toml.sample
@@ -157,6 +157,11 @@ RemoteNickFormat="[{PROTOCOL}] <{NICK}> "
 #OPTIONAL (default false)
 ShowJoinPart=false
 
+#Enable to show verbose users joins/parts (ident@host) from other bridges
+#Currently works for messages from the following bridges: irc
+#OPTIONAL (default false)
+VerboseJoinPart=false
+
 #Do not send joins/parts to other bridges
 #Currently works for messages from the following bridges: irc, mattermost, slack
 #OPTIONAL (default false)


### PR DESCRIPTION
### New option: VerboseJoinPart

- Show verbose users joins/parts (ident@host) from IRC
- New configuration setting: VerboseJoinPart (default is false)

I have only tested with IRC and Rocketchat, please review and optimize.

Thanks for your time.