### PR TITLE
Per default don't strip IRC colors to IRC channels (tengo)

### DIFF
--- a/contrib/example.tengo
+++ b/contrib/example.tengo
@@ -1,2 +1,13 @@
+/*
+variables available 
+read-only:
+inAccount, inProtocol, inChannel, inGateway
+outAccount, outProtocol, outChannel, outGateway
+
+read-write:
+msgText, msgUsername
+*/
+
 text := import("text")
+
 msgText=text.re_replace("matterbridge",msgText,"matterbridge (https://github.com/42wim/matterbridge)")

--- a/contrib/outmessage-irccolors.tengo
+++ b/contrib/outmessage-irccolors.tengo
@@ -12,7 +12,7 @@ text := import("text")
 
 // See https://github.com/42wim/matterbridge/issues/798
 // if we're not sending to an irc bridge we strip the IRC colors
-if outProtocol != "irc" {
+if (inProtocol == "irc") && (outProtocol != "irc") {
     re := text.re_compile(`\x03(?:\d{1,2}(?:,\d{1,2})?)?|[[:cntrl:]]`)
     msgText=re.replace(msgText,"")
 }

--- a/contrib/outmessage-irccolors.tengo
+++ b/contrib/outmessage-irccolors.tengo
@@ -1,5 +1,16 @@
-// See https://github.com/42wim/matterbridge/issues/798
+/*
+variables available 
+read-only:
+inAccount, inProtocol, inChannel, inGateway
+outAccount, outProtocol, outChannel, outGateway
 
+read-write:
+msgText, msgUsername
+*/
+
+text := import("text")
+
+// See https://github.com/42wim/matterbridge/issues/798
 // if we're not sending to an irc bridge we strip the IRC colors
 if outProtocol != "irc" {
     re := text.re_compile(`\x03(?:\d{1,2}(?:,\d{1,2})?)?|[[:cntrl:]]`)

--- a/contrib/remotenickformat.tengo
+++ b/contrib/remotenickformat.tengo
@@ -3,6 +3,7 @@ This script will return the current time in kitchen format if the protocol (of t
 See https://github.com/d5/tengo/blob/master/docs/stdlib-times.md
 This result can be used in {TENGO} in RemoteNickFormat
 */
+
 times := import("times")
 if protocol != "irc" {
    result=times.time_format(times.now(),times.format_kitchen)

--- a/internal/tengo/outmessage.tengo
+++ b/internal/tengo/outmessage.tengo
@@ -13,7 +13,7 @@ text := import("text")
 // start - strip irc colors 
 // if we're not sending to an irc bridge we strip the IRC colors
 if inProtocol == "irc" {
-    if OutProtocol != "irc" {
+    if outProtocol != "irc" {
     re := text.re_compile(`\x03(?:\d{1,2}(?:,\d{1,2})?)?|[[:cntrl:]]`)
     msgText=re.replace(msgText,"")
     }

--- a/internal/tengo/outmessage.tengo
+++ b/internal/tengo/outmessage.tengo
@@ -12,10 +12,8 @@ text := import("text")
 
 // start - strip irc colors 
 // if we're not sending to an irc bridge we strip the IRC colors
-if inProtocol == "irc" {
-    if outProtocol != "irc" {
+if (inProtocol == "irc") && (outProtocol != "irc") {
     re := text.re_compile(`\x03(?:\d{1,2}(?:,\d{1,2})?)?|[[:cntrl:]]`)
     msgText=re.replace(msgText,"")
-    }
 }
 // end - strip irc colors

--- a/internal/tengo/outmessage.tengo
+++ b/internal/tengo/outmessage.tengo
@@ -13,7 +13,9 @@ text := import("text")
 // start - strip irc colors 
 // if we're not sending to an irc bridge we strip the IRC colors
 if inProtocol == "irc" {
+    if OutProtocol != "irc" {
     re := text.re_compile(`\x03(?:\d{1,2}(?:,\d{1,2})?)?|[[:cntrl:]]`)
     msgText=re.replace(msgText,"")
+    }
 }
 // end - strip irc colors


### PR DESCRIPTION
Per default don't strip IRC colors to IRC channels (tengo).
Added missing variable and documentation to example tengo script in contrib/