### PR TITLE
Only forward user-typing messages if supported by protocol

### DIFF
--- a/gateway/bridgemap/bridgemap.go
+++ b/gateway/bridgemap/bridgemap.go
@@ -3,35 +3,41 @@ package bridgemap
 import (
 	"github.com/42wim/matterbridge/bridge"
 	"github.com/42wim/matterbridge/bridge/api"
-	"github.com/42wim/matterbridge/bridge/discord"
-	"github.com/42wim/matterbridge/bridge/gitter"
-	"github.com/42wim/matterbridge/bridge/irc"
-	"github.com/42wim/matterbridge/bridge/matrix"
-	"github.com/42wim/matterbridge/bridge/mattermost"
-	"github.com/42wim/matterbridge/bridge/rocketchat"
-	"github.com/42wim/matterbridge/bridge/slack"
-	"github.com/42wim/matterbridge/bridge/sshchat"
-	"github.com/42wim/matterbridge/bridge/steam"
-	"github.com/42wim/matterbridge/bridge/telegram"
-	"github.com/42wim/matterbridge/bridge/whatsapp"
-	"github.com/42wim/matterbridge/bridge/xmpp"
-	"github.com/42wim/matterbridge/bridge/zulip"
+	bdiscord "github.com/42wim/matterbridge/bridge/discord"
+	bgitter "github.com/42wim/matterbridge/bridge/gitter"
+	birc "github.com/42wim/matterbridge/bridge/irc"
+	bmatrix "github.com/42wim/matterbridge/bridge/matrix"
+	bmattermost "github.com/42wim/matterbridge/bridge/mattermost"
+	brocketchat "github.com/42wim/matterbridge/bridge/rocketchat"
+	bslack "github.com/42wim/matterbridge/bridge/slack"
+	bsshchat "github.com/42wim/matterbridge/bridge/sshchat"
+	bsteam "github.com/42wim/matterbridge/bridge/steam"
+	btelegram "github.com/42wim/matterbridge/bridge/telegram"
+	bwhatsapp "github.com/42wim/matterbridge/bridge/whatsapp"
+	bxmpp "github.com/42wim/matterbridge/bridge/xmpp"
+	bzulip "github.com/42wim/matterbridge/bridge/zulip"
 )
 
-var FullMap = map[string]bridge.Factory{
-	"api":          api.New,
-	"discord":      bdiscord.New,
-	"gitter":       bgitter.New,
-	"irc":          birc.New,
-	"mattermost":   bmattermost.New,
-	"matrix":       bmatrix.New,
-	"rocketchat":   brocketchat.New,
-	"slack-legacy": bslack.NewLegacy,
-	"slack":        bslack.New,
-	"sshchat":      bsshchat.New,
-	"steam":        bsteam.New,
-	"telegram":     btelegram.New,
-	"whatsapp":     bwhatsapp.New,
-	"xmpp":         bxmpp.New,
-	"zulip":        bzulip.New,
-}
+var (
+	FullMap = map[string]bridge.Factory{
+		"api":          api.New,
+		"discord":      bdiscord.New,
+		"gitter":       bgitter.New,
+		"irc":          birc.New,
+		"mattermost":   bmattermost.New,
+		"matrix":       bmatrix.New,
+		"rocketchat":   brocketchat.New,
+		"slack-legacy": bslack.NewLegacy,
+		"slack":        bslack.New,
+		"sshchat":      bsshchat.New,
+		"steam":        bsteam.New,
+		"telegram":     btelegram.New,
+		"whatsapp":     bwhatsapp.New,
+		"xmpp":         bxmpp.New,
+		"zulip":        bzulip.New,
+	}
+
+	UserTypingSupport = map[string]struct{}{
+		"slack": {},
+	}
+)

--- a/gateway/handlers.go
+++ b/gateway/handlers.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/42wim/matterbridge/bridge"
 	"github.com/42wim/matterbridge/bridge/config"
+	"github.com/42wim/matterbridge/gateway/bridgemap"
 )
 
 // handleEventFailure handles failures and reconnects bridges.
@@ -189,6 +190,14 @@ func (gw *Gateway) ignoreEvent(event string, dest *bridge.Bridge) bool {
 // Returns an array of msg ID's
 func (gw *Gateway) handleMessage(rmsg *config.Message, dest *bridge.Bridge) []*BrMsgID {
 	var brMsgIDs []*BrMsgID
+
+	// Not all bridges support "user is typing" indications so skip the message
+	// if the targeted bridge does not support it.
+	if rmsg.Event == config.EventUserTyping {
+		if _, ok := bridgemap.UserTypingSupport[dest.Protocol]; !ok {
+			return nil
+		}
+	}
 
 	// if we have an attached file, or other info
 	if rmsg.Extra != nil && len(rmsg.Extra[config.EventFileFailureSize]) != 0 && rmsg.Text == "" {


### PR DESCRIPTION
Fixes issue #814. 

This is a somewhat hacky way of achieving the required goal but it seems
like this is the least problematic way of getting there.

We might want to redesign some bridge information later such that we
have a standardised way of specifying what is and what isn't supported
by each chat protocol / bridge.