### PR TITLE
XMPP: verify TLS against JID domain, not the host.

### DIFF
--- a/bridge/xmpp/xmpp.go
+++ b/bridge/xmpp/xmpp.go
@@ -100,7 +100,7 @@ func (b *Bxmpp) Send(msg config.Message) (string, error) {
 
 func (b *Bxmpp) createXMPP() error {
 	tc := &tls.Config{
-		ServerName:         strings.Split(b.GetString("Server"), ":")[0],
+		ServerName:         strings.Split(b.GetString("Jid"), "@")[1],
 		InsecureSkipVerify: b.GetBool("SkipTLSVerify"), // nolint: gosec
 	}
 	options := xmpp.Options{


### PR DESCRIPTION
Partially fixes #820.

A full fix requires patching https://github.com/matterbridge/go-xmpp to use DNS SRV records.