### PR TITLE
Revert xmpp to orig behaviour. Closes #844

### DIFF
--- a/bridge/xmpp/xmpp.go
+++ b/bridge/xmpp/xmpp.go
@@ -332,5 +332,5 @@ func (b *Bxmpp) skipMessage(message xmpp.Chat) bool {
 	}
 
 	// skip delayed messages
-	return message.Stamp.IsZero()
+	return !message.Stamp.IsZero()
 }


### PR DESCRIPTION
Fix regression in xmpp, revert to original behaviour, skip messages that do not have a zero date