### PR TITLE
Allow messages with timestamp (xmpp). Fixes #835

### DIFF
--- a/bridge/xmpp/xmpp.go
+++ b/bridge/xmpp/xmpp.go
@@ -332,5 +332,5 @@ func (b *Bxmpp) skipMessage(message xmpp.Chat) bool {
 	}
 
 	// skip delayed messages
-	return !message.Stamp.IsZero()
+	return !message.Stamp.IsZero() || time.Since(message.Stamp).Minutes() > 5
 }


### PR DESCRIPTION
Forward messages that are not older then 5 minutes.