### PR TITLE
Fix regression in autojoining with legacy tokens (slack). Fixes #651

### DIFF
--- a/bridge/slack/legacy.go
+++ b/bridge/slack/legacy.go
@@ -13,7 +13,9 @@ type BLegacy struct {
 }
 
 func NewLegacy(cfg *bridge.Config) bridge.Bridger {
-	return &BLegacy{Bslack: newBridge(cfg)}
+	b := &BLegacy{Bslack: newBridge(cfg)}
+	b.legacy = true
+	return b
 }
 
 func (b *BLegacy) Connect() error {


### PR DESCRIPTION
Join a channel if we're in legacy mode, should make @patcon happy :-)