### PR TITLE
Add an option to skip the Mattermost server version check

### DIFF
--- a/bridge/config/config.go
+++ b/bridge/config/config.go
@@ -127,6 +127,7 @@ type Protocol struct {
 	ShowUserTyping         bool       // slack
 	ShowEmbeds             bool       // discord
 	SkipTLSVerify          bool       // IRC, mattermost
+	SkipVersionCheck       bool       // mattermost
 	StripNick              bool       // all protocols
 	SyncTopic              bool       // slack
 	TengoModifyMessage     string     // general

--- a/bridge/mattermost/helpers.go
+++ b/bridge/mattermost/helpers.go
@@ -70,6 +70,7 @@ func (b *Bmattermost) apiLogin() error {
 		b.mc.SetLogLevel("debug")
 	}
 	b.mc.SkipTLSVerify = b.GetBool("SkipTLSVerify")
+	b.mc.SkipVersionCheck = b.GetBool("SkipVersionCheck")
 	b.mc.NoTLS = b.GetBool("NoTLS")
 	b.Log.Infof("Connecting %s (team: %s) on %s", b.GetString("Login"), b.GetString("Team"), b.GetString("Server"))
 	err := b.mc.Login()

--- a/matterclient/helpers.go
+++ b/matterclient/helpers.go
@@ -198,8 +198,9 @@ func (m *MMClient) serverAlive(firstConnection bool, b *backoff.Backoff) error {
 				m.logger.Infof("Found version %s", m.ServerVersion)
 				return nil
 			}
+		} else {
+			return nil
 		}
-		return nil
 	}
 }
 

--- a/matterclient/helpers.go
+++ b/matterclient/helpers.go
@@ -186,17 +186,20 @@ func (m *MMClient) serverAlive(firstConnection bool, b *backoff.Backoff) error {
 		if resp.Error != nil {
 			return fmt.Errorf("%#v", resp.Error.Error())
 		}
-		if firstConnection && !supportedVersion(resp.ServerVersion) {
+		if firstConnection && !m.SkipVersionCheck && !supportedVersion(resp.ServerVersion) {
 			return fmt.Errorf("unsupported mattermost version: %s", resp.ServerVersion)
 		}
-		m.ServerVersion = resp.ServerVersion
-		if m.ServerVersion == "" {
-			m.logger.Debugf("Server not up yet, reconnecting in %s", d)
-			time.Sleep(d)
-		} else {
-			m.logger.Infof("Found version %s", m.ServerVersion)
-			return nil
+		if !m.SkipVersionCheck {
+			m.ServerVersion = resp.ServerVersion
+			if m.ServerVersion == "" {
+				m.logger.Debugf("Server not up yet, reconnecting in %s", d)
+				time.Sleep(d)
+			} else {
+				m.logger.Infof("Found version %s", m.ServerVersion)
+				return nil
+			}
 		}
+		return nil
 	}
 }
 

--- a/matterclient/matterclient.go
+++ b/matterclient/matterclient.go
@@ -16,14 +16,15 @@ import (
 )
 
 type Credentials struct {
-	Login         string
-	Team          string
-	Pass          string
-	Token         string
-	CookieToken   bool
-	Server        string
-	NoTLS         bool
-	SkipTLSVerify bool
+	Login            string
+	Team             string
+	Pass             string
+	Token            string
+	CookieToken      bool
+	Server           string
+	NoTLS            bool
+	SkipTLSVerify    bool
+	SkipVersionCheck bool
 }
 
 type Message struct {


### PR DESCRIPTION
This pull request adds a new bool configuration option: `SkipVersionCheck` that can be used to skip the Mattermost server version checks that are normally done when connecting. 

The usage scenario for this feature would be when the Mattermost instance is hosted behind a reverse proxy that suppresses "non-standard" response headers in flight. If the option is not defined in such scenario, `matterbridge` will fail to connect with an error message: 
```
[0000] FATAL main:         Starting gateway failed: Bridge mattermost.whatever failed to start: unsupported mattermost version:
```