### PR TITLE
Fix #860: discord channel & category name clash

### DIFF
--- a/bridge/discord/discord.go
+++ b/bridge/discord/discord.go
@@ -95,7 +95,8 @@ func (b *Bdiscord) Connect() error {
 	b.channelsMutex.Lock()
 	for _, guild := range guilds {
 		if guild.Name == serverName || guild.ID == serverName {
-			chans, err := b.c.GuildChannels(guild.ID)
+			var chans []*discordgo.Channel
+			chans, err = b.c.GuildChannels(guild.ID)
 			if err != nil {
 				break
 			}

--- a/bridge/discord/discord.go
+++ b/bridge/discord/discord.go
@@ -95,12 +95,13 @@ func (b *Bdiscord) Connect() error {
 	b.channelsMutex.Lock()
 	for _, guild := range guilds {
 		if guild.Name == serverName || guild.ID == serverName {
-			b.channels, err = b.c.GuildChannels(guild.ID)
-			b.guildID = guild.ID
-			guildFound = true
+			chans, err := b.c.GuildChannels(guild.ID)
 			if err != nil {
 				break
 			}
+			b.channels = filterChannelsByType(chans, discordgo.ChannelTypeGuildText, false)
+			b.guildID = guild.ID
+			guildFound = true
 		}
 	}
 	b.channelsMutex.Unlock()

--- a/bridge/discord/helpers.go
+++ b/bridge/discord/helpers.go
@@ -88,13 +88,13 @@ var (
 
 func (b *Bdiscord) replaceChannelMentions(text string) string {
 	replaceChannelMentionFunc := func(match string) string {
-		var err error
 		channelID := match[2 : len(match)-1]
-
 		channelName := b.getChannelName(channelID)
+
 		// If we don't have the channel refresh our list.
 		if channelName == "" {
-			b.channels, err = b.c.GuildChannels(b.guildID)
+			chans, err := b.c.GuildChannels(b.guildID)
+			b.channels = filterChannelsByType(chans, discordgo.ChannelTypeGuildCategory, true)
 			if err != nil {
 				return "#unknownchannel"
 			}
@@ -210,4 +210,20 @@ func (b *Bdiscord) webhookExecute(webhookID, token string, wait bool, data *disc
 	}
 
 	return st, nil
+}
+
+func filterChannelsByType(chans []*discordgo.Channel, t discordgo.ChannelType, filterOut bool) []*discordgo.Channel {
+	cs := []*discordgo.Channel{}
+	for _, c := range chans {
+		keep := c.Type == t
+		if filterOut {
+			keep = c.Type != t
+		}
+
+		if keep {
+			cs = append(cs, c)
+		}
+	}
+	return cs
+
 }


### PR DESCRIPTION
Untested, sorry.

Fixes #860