### PR TITLE
Add support for discord category channels (discord)

### DIFF
--- a/bridge/discord/discord.go
+++ b/bridge/discord/discord.go
@@ -95,12 +95,10 @@ func (b *Bdiscord) Connect() error {
 	b.channelsMutex.Lock()
 	for _, guild := range guilds {
 		if guild.Name == serverName || guild.ID == serverName {
-			var chans []*discordgo.Channel
-			chans, err = b.c.GuildChannels(guild.ID)
+			b.channels, err = b.c.GuildChannels(guild.ID)
 			if err != nil {
 				break
 			}
-			b.channels = filterChannelsByType(chans, discordgo.ChannelTypeGuildText, false)
 			b.guildID = guild.ID
 			guildFound = true
 		}

--- a/matterbridge.toml.sample
+++ b/matterbridge.toml.sample
@@ -1553,6 +1553,7 @@ enable=true
     # discord    - channel (without the #)
     #            - ID:123456789 (where 123456789 is the channel ID)
     #               (https://github.com/42wim/matterbridge/issues/57)
+    #            - category/channel (without the #) if you're using discord categories to group your channels
     # telegram   - chatid (a large negative number, eg -123456789)
     #             see (https://www.linkedin.com/pulse/telegram-bots-beginners-marco-frau)
     # hipchat    - id_channel (see https://www.hipchat.com/account/xmpp for the correct channel)


### PR DESCRIPTION
This adds support for the discord category option that can be used
to group channels in. This means we can have multiple channels with
the same name.

We add the option to specify a category in the channel option of a
discord account under `[[gateway]]`

Besides `channel="channel"` or `channel="ID:channelID"`, now also
`channel="category/channel"` can be specified.

This change remains backwards compatible with people that haven't
specified the category and incorporates the fix in #861

@qaisjp sorry but this roll backs a bit of your code in #861 

Any comments?