### PR TITLE
make getChannelIdTeam behave like GetChannelId for groups

### DIFF
--- a/matterclient/channels.go
+++ b/matterclient/channels.go
@@ -38,7 +38,7 @@ func (m *MMClient) GetChannelHeader(channelId string) string { //nolint:golint
 
 func getNormalisedName(channel *model.Channel) string {
 	if channel.Type == model.CHANNEL_GROUP {
-		// (deprecated in favour of ReplaceAll in go 1.12)
+		// (deprecated in favor of ReplaceAll in go 1.12)
 		res := strings.Replace(channel.DisplayName, ", ", "-", -1) //nolint: gocritic
 		res = strings.Replace(res, " ", "_", -1)                   //nolint: gocritic
 		return res

--- a/matterclient/channels.go
+++ b/matterclient/channels.go
@@ -36,6 +36,15 @@ func (m *MMClient) GetChannelHeader(channelId string) string { //nolint:golint
 	return ""
 }
 
+func getNormalisedName(channel *model.Channel) string {
+	if channel.Type == model.CHANNEL_GROUP {
+		res := strings.Replace(channel.DisplayName, ", ", "-", -1)
+		res = strings.Replace(res, " ", "_", -1)
+		return res
+	}
+	return channel.Name
+}
+
 func (m *MMClient) GetChannelId(name string, teamId string) string { //nolint:golint
 	m.RLock()
 	defer m.RUnlock()
@@ -45,13 +54,7 @@ func (m *MMClient) GetChannelId(name string, teamId string) string { //nolint:go
 
 	for _, t := range m.OtherTeams {
 		for _, channel := range append(t.Channels, t.MoreChannels...) {
-			if channel.Type == model.CHANNEL_GROUP {
-				res := strings.Replace(channel.DisplayName, ", ", "-", -1)
-				res = strings.Replace(res, " ", "_", -1)
-				if res == name {
-					return channel.Id
-				}
-			} else if channel.Name == name {
+			if getNormalisedName(channel) == name {
 				return channel.Id
 			}
 		}
@@ -63,13 +66,7 @@ func (m *MMClient) getChannelIdTeam(name string, teamId string) string { //nolin
 	for _, t := range m.OtherTeams {
 		if t.Id == teamId {
 			for _, channel := range append(t.Channels, t.MoreChannels...) {
-				if channel.Type == model.CHANNEL_GROUP {
-					res := strings.Replace(channel.DisplayName, ", ", "-", -1)
-					res = strings.Replace(res, " ", "_", -1)
-					if res == name {
-						return channel.Id
-					}
-				} else if channel.Name == name {
+				if getNormalisedName(channel) == name {
 					return channel.Id
 				}
 			}
@@ -87,12 +84,7 @@ func (m *MMClient) GetChannelName(channelId string) string { //nolint:golint
 		}
 		for _, channel := range append(t.Channels, t.MoreChannels...) {
 			if channel.Id == channelId {
-				if channel.Type == model.CHANNEL_GROUP {
-					res := strings.Replace(channel.DisplayName, ", ", "-", -1)
-					res = strings.Replace(res, " ", "_", -1)
-					return res
-				}
-				return channel.Name
+				return getNormalisedName(channel)
 			}
 		}
 	}

--- a/matterclient/channels.go
+++ b/matterclient/channels.go
@@ -63,7 +63,13 @@ func (m *MMClient) getChannelIdTeam(name string, teamId string) string { //nolin
 	for _, t := range m.OtherTeams {
 		if t.Id == teamId {
 			for _, channel := range append(t.Channels, t.MoreChannels...) {
-				if channel.Name == name {
+				if channel.Type == model.CHANNEL_GROUP {
+					res := strings.Replace(channel.DisplayName, ", ", "-", -1)
+					res = strings.Replace(res, " ", "_", -1)
+					if res == name {
+						return channel.Id
+					}
+				} else if channel.Name == name {
 					return channel.Id
 				}
 			}

--- a/matterclient/channels.go
+++ b/matterclient/channels.go
@@ -39,8 +39,8 @@ func (m *MMClient) GetChannelHeader(channelId string) string { //nolint:golint
 func getNormalisedName(channel *model.Channel) string {
 	if channel.Type == model.CHANNEL_GROUP {
 		// (deprecated in favour of ReplaceAll in go 1.12)
-		res := strings.Replace(channel.DisplayName, ", ", "-", -1) // nolint: gocritic
-		res = strings.Replace(res, " ", "_", -1) // nolint: gocritic
+		res := strings.Replace(channel.DisplayName, ", ", "-", -1) //nolint: gocritic
+		res = strings.Replace(res, " ", "_", -1)                   //nolint: gocritic
 		return res
 	}
 	return channel.Name

--- a/matterclient/channels.go
+++ b/matterclient/channels.go
@@ -38,8 +38,9 @@ func (m *MMClient) GetChannelHeader(channelId string) string { //nolint:golint
 
 func getNormalisedName(channel *model.Channel) string {
 	if channel.Type == model.CHANNEL_GROUP {
-		res := strings.Replace(channel.DisplayName, ", ", "-", -1)
-		res = strings.Replace(res, " ", "_", -1)
+		// (deprecated in favour of ReplaceAll in go 1.12)
+		res := strings.Replace(channel.DisplayName, ", ", "-", -1) // nolint: gocritic
+		res = strings.Replace(res, " ", "_", -1) // nolint: gocritic
 		return res
 	}
 	return channel.Name


### PR DESCRIPTION
`GetChannelId` will support names generated from query groups when a team is not set, but *not* when a team is set since it falls through to `getChannelIdTeam` which has a different inner loop. This pull makes the two implementations do the same thing.