### PR TITLE
Specify correct GuildID on unknown user query.  Fixes #879

### DIFF
--- a/bridge/discord/handlers.go
+++ b/bridge/discord/handlers.go
@@ -89,7 +89,7 @@ func (b *Bdiscord) messageCreate(s *discordgo.Session, m *discordgo.MessageCreat
 
 	// set username
 	if !b.GetBool("UseUserName") {
-		rmsg.Username = b.getNick(m.Author)
+		rmsg.Username = b.getNick(m.Author, m.GuildID)
 	} else {
 		rmsg.Username = m.Author.Username
 		if b.GetBool("UseDiscriminator") {

--- a/bridge/discord/helpers.go
+++ b/bridge/discord/helpers.go
@@ -9,7 +9,7 @@ import (
 	"github.com/bwmarrin/discordgo"
 )
 
-func (b *Bdiscord) getNick(user *discordgo.User) string {
+func (b *Bdiscord) getNick(user *discordgo.User, guildID string) string {
 	b.membersMutex.RLock()
 	defer b.membersMutex.RUnlock()
 
@@ -23,9 +23,9 @@ func (b *Bdiscord) getNick(user *discordgo.User) string {
 	}
 
 	// If we didn't find nick, search for it.
-	member, err := b.c.GuildMember(b.guildID, user.ID)
+	member, err := b.c.GuildMember(guildID, user.ID)
 	if err != nil {
-		b.Log.Warnf("Failed to fetch information for member %#v on guild %#v: %s", user, b.guildID, err)
+		b.Log.Warnf("Failed to fetch information for member %#v on guild %#v: %s", user, guildID, err)
 		return user.Username
 	} else if member == nil {
 		b.Log.Warnf("Got no information for member %#v", user)


### PR DESCRIPTION
We have the GuildID in the message, use this.