### PR TITLE
Add support for receiving attachments (keybase)

### DIFF
--- a/bridge/keybase/keybase.go
+++ b/bridge/keybase/keybase.go
@@ -79,16 +79,21 @@ func (b *Bkeybase) Send(msg config.Message) (string, error) {
 			return "", err
 		}
 		defer os.RemoveAll(dir)
-		fname := msg.Extra["file"][0].(config.FileInfo).Name
-		fdata := *msg.Extra["file"][0].(config.FileInfo).Data
-		fcaption := msg.Extra["file"][0].(config.FileInfo).Comment
-		fpath := filepath.Join(dir, fname)
-		if err = ioutil.WriteFile(fpath, fdata, 0600); err != nil {
-			return "", err
+
+		for _, f := range msg.Extra["file"] {
+			fname := f.(config.FileInfo).Name
+			fdata := *f.(config.FileInfo).Data
+			fcaption := f.(config.FileInfo).Comment
+			fpath := filepath.Join(dir, fname)
+
+			if err = ioutil.WriteFile(fpath, fdata, 0600); err != nil {
+				return "", err
+			}
+
+			_, _ = b.kbc.SendAttachmentByTeam(b.team, fpath, fcaption, &b.channel)
 		}
 
-		resp, err := b.kbc.SendAttachmentByTeam(b.team, fpath, fcaption, &b.channel)
-		return strconv.Itoa(resp.Result.MsgID), err
+		return "", nil
 	}
 
 	// Send regular message

--- a/bridge/keybase/keybase.go
+++ b/bridge/keybase/keybase.go
@@ -1,10 +1,10 @@
 package bkeybase
 
 import (
-	"strconv"
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strconv"
 
 	"github.com/42wim/matterbridge/bridge"
 	"github.com/42wim/matterbridge/bridge/config"
@@ -80,19 +80,21 @@ func (b *Bkeybase) Send(msg config.Message) (string, error) {
 		}
 		defer os.RemoveAll(dir)
 		fname := msg.Extra["file"][0].(config.FileInfo).Name
-		fpath := filepath.Join(dir, msg.Extra["file"][0].(config.FileInfo).Name)
-		if err := ioutil.WriteFile(fpath, *msg.Extra["file"][0].(config.FileInfo).Data, 0600); err != nil {
+		fdata := *msg.Extra["file"][0].(config.FileInfo).Data
+		fcaption := msg.Extra["file"][0].(config.FileInfo).Comment
+		fpath := filepath.Join(dir, fname)
+		if err = ioutil.WriteFile(fpath, fdata, 0600); err != nil {
 			return "", err
 		}
 
-		resp, err := b.kbc.SendAttachmentByTeam(b.team, fpath, fname, &b.channel)
-		return strconv.Itoa(resp.Result.MsgID), err
-	} else {
-		// Send regular message
-		resp, err := b.kbc.SendMessageByTeamName(b.team, msg.Username+msg.Text, &b.channel)
-		if err != nil {
-			return "", err
-		}
+		resp, err := b.kbc.SendAttachmentByTeam(b.team, fpath, fcaption, &b.channel)
 		return strconv.Itoa(resp.Result.MsgID), err
 	}
+
+	// Send regular message
+	resp, err := b.kbc.SendMessageByTeamName(b.team, msg.Username+msg.Text, &b.channel)
+	if err != nil {
+		return "", err
+	}
+	return strconv.Itoa(resp.Result.MsgID), err
 }


### PR DESCRIPTION
These changes make the Keybase bridge able to receive attachments.
It seems the Keybase API does not currently support uploading files directly from RAM, so the file has to be temporarily written to the filesystem before uploading and is removed afterwards.

I tested these changes by sending attachments from Telegram to Keybase.
This is my first time both contributing to this project and writing Go. Improvements/suggestions are appreciated.