### PR TITLE
Convert slack bold/strike to correct markdown (slack). Fixes #918

### DIFF
--- a/bridge/slack/handlers.go
+++ b/bridge/slack/handlers.go
@@ -30,6 +30,7 @@ func (b *Bslack) handleSlack() {
 			message.Text = b.replaceVariable(message.Text)
 			message.Text = b.replaceChannel(message.Text)
 			message.Text = b.replaceURL(message.Text)
+			message.Text = b.replaceb0rkedMarkDown(message.Text)
 			message.Text = html.UnescapeString(message.Text)
 
 			// Add the avatar

--- a/bridge/slack/helpers.go
+++ b/bridge/slack/helpers.go
@@ -188,6 +188,36 @@ func (b *Bslack) replaceURL(text string) string {
 	return text
 }
 
+func (b *Bslack) replaceb0rkedMarkDown(text string) string {
+	// taken from https://github.com/mattermost/mattermost-server/blob/master/app/slackimport.go
+	//
+	regexReplaceAllString := []struct {
+		regex *regexp.Regexp
+		rpl   string
+	}{
+		// bold
+		{
+			regexp.MustCompile(`(^|[\s.;,])\*(\S[^*\n]+)\*`),
+			"$1**$2**",
+		},
+		// strikethrough
+		{
+			regexp.MustCompile(`(^|[\s.;,])\~(\S[^~\n]+)\~`),
+			"$1~~$2~~",
+		},
+		// single paragraph blockquote
+		// Slack converts > character to &gt;
+		{
+			regexp.MustCompile(`(?sm)^&gt;`),
+			">",
+		},
+	}
+	for _, rule := range regexReplaceAllString {
+		text = rule.regex.ReplaceAllString(text, rule.rpl)
+	}
+	return text
+}
+
 func (b *Bslack) replaceCodeFence(text string) string {
 	return codeFenceRE.ReplaceAllString(text, "```")
 }


### PR DESCRIPTION
Quick hack to fix this, should be handled correctly when time permits.