### PR TITLE
Remove obsolete file upload links (discord). Fixes #908

### DIFF
--- a/bridge/discord/discord.go
+++ b/bridge/discord/discord.go
@@ -234,18 +234,6 @@ func (b *Bdiscord) Send(msg config.Message) (string, error) {
 		}
 
 		b.Log.Debugf("Broadcasting using Webhook")
-		for _, f := range msg.Extra["file"] {
-			fi := f.(config.FileInfo)
-			if fi.Comment != "" {
-				msg.Text += fi.Comment + ": "
-			}
-			if fi.URL != "" {
-				msg.Text = fi.URL
-				if fi.Comment != "" {
-					msg.Text = fi.Comment + ": " + fi.URL
-				}
-			}
-		}
 
 		// skip empty messages
 		if msg.Text == "" && (msg.Extra == nil || len(msg.Extra["file"]) == 0) {


### PR DESCRIPTION
Since v1.16.0 we now can upload files via webhook.
Old way of showing files with webhook only setup can be removed.