### PR TITLE
README: Add link to Ansible role for Matterbridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ See [FAQ](https://github.com/42wim/matterbridge/wiki/FAQ)
 
 ## Related projects
 
-- [FOSSRIT/infrastructure - roles/matterbridge](https://github.com/FOSSRIT/infrastructure/tree/master/roles/matterbridge) (Ansible role used to automate deployments of Matterbridge)
+- [jwflory/ansible-role-matterbridge](https://galaxy.ansible.com/jwflory/matterbridge) (Ansible role to simplify deploying Matterbridge)
 - [matterbridge autoconfig](https://github.com/patcon/matterbridge-autoconfig)
 - [matterbridge config viewer](https://github.com/patcon/matterbridge-heroku-viewer)
 - [matterbridge-heroku](https://github.com/cadecairos/matterbridge-heroku)


### PR DESCRIPTION
This commit replaces the FOSSRIT/infrastructure link to the Matterbridge
role to a properly-defined Ansible role published in Ansible Galaxy. I
am the maintainer of the FOSSRIT/infrastructure repo and I decided to
split the Ansible role there into its own dedicated role. I figure this
might make it more accessible to others and also gives other folks a
chance to contribute. :smile: