### PR TITLE
 move stripCustomoji logic to default Tengo script

### DIFF
--- a/bridge/discord/handlers.go
+++ b/bridge/discord/handlers.go
@@ -88,7 +88,6 @@ func (b *Bdiscord) messageCreate(s *discordgo.Session, m *discordgo.MessageCreat
 
 	if m.Content != "" {
 		b.Log.Debugf("== Receiving event %#v", m.Message)
-		m.Message.Content = b.stripCustomoji(m.Message.Content)
 		m.Message.Content = b.replaceChannelMentions(m.Message.Content)
 		rmsg.Text, err = m.ContentWithMoreMentionsReplaced(b.c)
 		if err != nil {

--- a/bridge/discord/helpers.go
+++ b/bridge/discord/helpers.go
@@ -129,7 +129,6 @@ func (b *Bdiscord) getCategoryChannelName(name, parentID string) string {
 var (
 	// See https://discordapp.com/developers/docs/reference#message-formatting.
 	channelMentionRE = regexp.MustCompile("<#[0-9]+>")
-	emojiRE          = regexp.MustCompile("<(:.*?:)[0-9]+>")
 	userMentionRE    = regexp.MustCompile("@[^@\n]{1,32}")
 )
 
@@ -174,10 +173,6 @@ func (b *Bdiscord) replaceUserMentions(text string) string {
 		return strings.Replace(match, "@"+username, member.User.Mention(), 1)
 	}
 	return userMentionRE.ReplaceAllStringFunc(text, replaceUserMentionFunc)
-}
-
-func (b *Bdiscord) stripCustomoji(text string) string {
-	return emojiRE.ReplaceAllString(text, `$1`)
 }
 
 func (b *Bdiscord) replaceAction(text string) (string, bool) {

--- a/internal/tengo/outmessage.tengo
+++ b/internal/tengo/outmessage.tengo
@@ -12,7 +12,7 @@ text := import("text")
 
 // start - strip irc colors 
 // if we're not sending to an irc bridge we strip the IRC colors
-if inProtocol == "irc" {
+if inProtocol == "irc" && outProtocol != "irc" {
     re := text.re_compile(`\x03(?:\d{1,2}(?:,\d{1,2})?)?|[[:cntrl:]]`)
     msgText=re.replace(msgText,"")
 }

--- a/internal/tengo/outmessage.tengo
+++ b/internal/tengo/outmessage.tengo
@@ -20,6 +20,6 @@ if inProtocol == "irc" && outProtocol != "irc" {
 
 // strip custom emoji
 if inProtocol == "discord" {
-   re := text.re_compile(`<a?(:.*?:)[0-9]+>`)
+    re := text.re_compile(`<a?(:.*?:)[0-9]+>`)
     msgText=re.replace(msgText,"$1")
 }

--- a/internal/tengo/outmessage.tengo
+++ b/internal/tengo/outmessage.tengo
@@ -17,3 +17,9 @@ if inProtocol == "irc" && outProtocol != "irc" {
     msgText=re.replace(msgText,"")
 }
 // end - strip irc colors
+
+// strip custom emoji
+if inProtocol == "discord" {
+   re := text.re_compile(`<a?(:.*?:)[0-9]+>`)
+    msgText=re.replace(msgText,"$1")
+}


### PR DESCRIPTION
### The problem
Removing the image ID from the message (without any possibility of recovering it later) is a loss of valuable data that prevents Matterbridge users from giving support to custom emoji via Tengo scripts.

### The solution
By moving the stripCustomoji function logic to the default outmessage.tengo script we obtain the same end result while giving the user the option of overriding this logic and creating their own techniques to work on the image id (now available). This is particularly useful -for instance- to convert custom emoji markdown tags into urls, so that clients like converse.js (xmpp) can display these images just like the official discord client does.

### Example technique
By using this Tengo script:
```
text := import("text")

// turn custom emoji tags into url's for xmpp
if (inProtocol == "discord" && outProtocol == "xmpp") {
    rePNG := text.re_compile(`<:.*?:([0-9]+)>`)
    msgText=rePNG.replace(msgText,"https://cdn.discordapp.com/emojis/$1.png")
    reGIF := text.re_compile(`<a:.*?:([0-9]+)>`)
    msgText=reGIF.replace(msgText,"https://cdn.discordapp.com/emojis/$1.gif")
}
```
the message
`<:emoji_name:611124225839156144>`
becomes
`https://cdn.discordapp.com/emojis/611124225839156144.png`
