### PR TITLE
Fix channel ID problem with multiple gateways (discord). Fixes #953

### DIFF
--- a/bridge/discord/discord.go
+++ b/bridge/discord/discord.go
@@ -21,7 +21,6 @@ type Bdiscord struct {
 	c *discordgo.Session
 
 	nick            string
-	useChannelID    bool
 	guildID         string
 	webhookID       string
 	webhookToken    string
@@ -174,10 +173,6 @@ func (b *Bdiscord) JoinChannel(channel config.ChannelInfo) error {
 	defer b.channelsMutex.Unlock()
 
 	b.channelInfoMap[channel.ID] = &channel
-	idcheck := strings.Split(channel.Name, "ID:")
-	if len(idcheck) > 1 {
-		b.useChannelID = true
-	}
 	return nil
 }
 

--- a/bridge/discord/handlers.go
+++ b/bridge/discord/handlers.go
@@ -8,9 +8,7 @@ import (
 func (b *Bdiscord) messageDelete(s *discordgo.Session, m *discordgo.MessageDelete) { //nolint:unparam
 	rmsg := config.Message{Account: b.Account, ID: m.ID, Event: config.EventMsgDelete, Text: config.EventMsgDelete}
 	rmsg.Channel = b.getChannelName(m.ChannelID)
-	if b.useChannelID {
-		rmsg.Channel = "ID:" + m.ChannelID
-	}
+
 	b.Log.Debugf("<= Sending message from %s to gateway", b.Account)
 	b.Log.Debugf("<= Message is %#v", rmsg)
 	b.Remote <- rmsg
@@ -24,11 +22,7 @@ func (b *Bdiscord) messageDeleteBulk(s *discordgo.Session, m *discordgo.MessageD
 			ID:      msgID,
 			Event:   config.EventMsgDelete,
 			Text:    config.EventMsgDelete,
-			Channel: "ID:" + m.ChannelID,
-		}
-
-		if !b.useChannelID {
-			rmsg.Channel = b.getChannelName(m.ChannelID)
+			Channel: b.getChannelName(m.ChannelID),
 		}
 
 		b.Log.Debugf("<= Sending message from %s to gateway", b.Account)
@@ -44,9 +38,6 @@ func (b *Bdiscord) messageTyping(s *discordgo.Session, m *discordgo.TypingStart)
 
 	rmsg := config.Message{Account: b.Account, Event: config.EventUserTyping}
 	rmsg.Channel = b.getChannelName(m.ChannelID)
-	if b.useChannelID {
-		rmsg.Channel = "ID:" + m.ChannelID
-	}
 	b.Remote <- rmsg
 }
 
@@ -98,9 +89,6 @@ func (b *Bdiscord) messageCreate(s *discordgo.Session, m *discordgo.MessageCreat
 
 	// set channel name
 	rmsg.Channel = b.getChannelName(m.ChannelID)
-	if b.useChannelID {
-		rmsg.Channel = "ID:" + m.ChannelID
-	}
 
 	// set username
 	if !b.GetBool("UseUserName") {

--- a/bridge/discord/helpers.go
+++ b/bridge/discord/helpers.go
@@ -96,6 +96,13 @@ func (b *Bdiscord) getChannelName(id string) string {
 	b.channelsMutex.RLock()
 	defer b.channelsMutex.RUnlock()
 
+	for _, c := range b.channelInfoMap {
+		if c.Name == "ID:"+id {
+			// if we have ID: specified in our gateway configuration return this
+			return c.Name
+		}
+	}
+
 	for _, channel := range b.channels {
 		if channel.ID == id {
 			return b.getCategoryChannelName(channel.Name, channel.ParentID)


### PR DESCRIPTION
Remove global boolean that caused the issue and return channel with ID if we have so in our config.