### PR TITLE
Adding QuoteLengthLimit option for Feature request: #963

### DIFF
--- a/bridge/config/config.go
+++ b/bridge/config/config.go
@@ -116,6 +116,7 @@ type Protocol struct {
 	Protocol               string     // all protocols
 	QuoteDisable           bool       // telegram
 	QuoteFormat            string     // telegram
+	QuoteLengthLimit       int        // telegram
 	RejoinDelay            int        // IRC
 	ReplaceMessages        [][]string // all protocols
 	ReplaceNicks           [][]string // all protocols

--- a/bridge/telegram/handlers.go
+++ b/bridge/telegram/handlers.go
@@ -362,7 +362,7 @@ func (b *Btelegram) handleQuote(message, quoteNick, quoteMessage string) string 
 		runes := []rune(quoteMessage)
 		quoteMessage = string(runes[0:b.GetInt("QuoteLengthLimit")])
 		if quoteMessagelength > b.GetInt("QuoteLengthLimit") {
-			quoteMessage = quoteMessage + "..."
+			quoteMessage += "..."
 		}
 	}
 	format = strings.Replace(format, "{MESSAGE}", message, -1)

--- a/bridge/telegram/handlers.go
+++ b/bridge/telegram/handlers.go
@@ -357,6 +357,14 @@ func (b *Btelegram) handleQuote(message, quoteNick, quoteMessage string) string 
 	if format == "" {
 		format = "{MESSAGE} (re @{QUOTENICK}: {QUOTEMESSAGE})"
 	}
+	quoteMessagelength := len(quoteMessage)
+	if b.GetInt("QuoteLengthLimit") != 0 && quoteMessagelength >= b.GetInt("QuoteLengthLimit") {
+		runes := []rune(quoteMessage)
+		quoteMessage = string(runes[0:b.GetInt("QuoteLengthLimit")])
+		if quoteMessagelength > b.GetInt("QuoteLengthLimit") {
+			quoteMessage = quoteMessage + "..."
+		}
+	}
 	format = strings.Replace(format, "{MESSAGE}", message, -1)
 	format = strings.Replace(format, "{QUOTENICK}", quoteNick, -1)
 	format = strings.Replace(format, "{QUOTEMESSAGE}", quoteMessage, -1)

--- a/matterbridge.toml.sample
+++ b/matterbridge.toml.sample
@@ -853,6 +853,10 @@ UseInsecureURL=false
 #OPTIONAL (default false)
 QuoteDisable=false
 
+#Set the max. quoted length if 0 the whole message will be quoted
+#OPTIONAL (default 0)
+QuoteLengthLimit=0
+
 #Format quoted/reply messages
 #OPTIONAL (default "{MESSAGE} (re @{QUOTENICK}: {QUOTEMESSAGE})")
 QuoteFormat="{MESSAGE} (re @{QUOTENICK}: {QUOTEMESSAGE})"


### PR DESCRIPTION
FR #963 asked for an option to limit the max quoted message length.
QuoteLengthLimit option added to limit max. quoted message length.
If QuoteLengthLimit = 0 the whole message will be quoted.
