### PR TITLE
Enable intra-word emphasis supression in markdown

### DIFF
--- a/bridge/helper/helper.go
+++ b/bridge/helper/helper.go
@@ -180,7 +180,7 @@ func ClipMessage(text string, length int) string {
 
 // ParseMarkdown takes in an input string as markdown and parses it to html
 func ParseMarkdown(input string) string {
-	extensions := parser.HardLineBreak
+	extensions := parser.HardLineBreak | parser.NoIntraEmphasis
 	markdownParser := parser.NewWithExtensions(extensions)
 	renderer := html.NewRenderer(html.RendererOptions{
 		Flags: 0,


### PR DESCRIPTION
This fixes plain links sent to Matrix being broken if they contain
underscores. Fixes issue #997