### PR TITLE
Add ability to procure avatars from the destination bridge

### DIFF
--- a/bridge/config/config.go
+++ b/bridge/config/config.go
@@ -138,6 +138,7 @@ type Protocol struct {
 	Topic                  string     // zulip
 	URL                    string     // mattermost, slack // DEPRECATED
 	UseAPI                 bool       // mattermost, slack
+	UseLocalAvatar         []string   // discord
 	UseSASL                bool       // IRC
 	UseTLS                 bool       // IRC
 	UseDiscriminator       bool       // discord

--- a/bridge/discord/discord.go
+++ b/bridge/discord/discord.go
@@ -384,7 +384,7 @@ func (b *Bdiscord) webhookSend(msg *config.Message, webhookID, token string) (*d
 	// If avatar is unset, maybe we need to set the local avatar
 	if msg.Avatar == "" {
 		for _, val := range b.GetStringSlice("UseLocalAvatar") {
-			if msg.Protocol != val {
+			if msg.Protocol != val && msg.Account != val {
 				continue
 			}
 			if avatar, ok := b.findAvatar(msg); ok {

--- a/bridge/discord/discord.go
+++ b/bridge/discord/discord.go
@@ -381,6 +381,19 @@ func (b *Bdiscord) webhookSend(msg *config.Message, webhookID, token string) (*d
 		err error
 	)
 
+	// If avatar is unset, maybe we need to set the local avatar
+	if msg.Avatar == "" {
+		for _, val := range b.GetStringSlice("UseLocalAvatar") {
+			if msg.Protocol != val {
+				continue
+			}
+			if avatar, ok := b.findAvatar(msg); ok {
+				msg.Avatar = avatar
+			}
+			break
+		}
+	}
+
 	// WebhookParams can have either `Content` or `File`.
 
 	// We can't send empty messages.
@@ -429,4 +442,12 @@ func (b *Bdiscord) webhookSend(msg *config.Message, webhookID, token string) (*d
 		}
 	}
 	return res, err
+}
+
+func (b *Bdiscord) findAvatar(m *config.Message) (string, bool) {
+	member, err := b.getGuildMemberByNick(m.Username)
+	if err != nil {
+		return "", false
+	}
+	return member.User.AvatarURL(""), true
 }

--- a/bridge/discord/discord.go
+++ b/bridge/discord/discord.go
@@ -381,16 +381,16 @@ func (b *Bdiscord) webhookSend(msg *config.Message, webhookID, token string) (*d
 		err error
 	)
 
-	// If avatar is unset, maybe we need to set the local avatar
+	// If avatar is unset, check if UseLocalAvatar contains the message's
+	// account or protocol, and if so, try to find a local avatar
 	if msg.Avatar == "" {
 		for _, val := range b.GetStringSlice("UseLocalAvatar") {
-			if msg.Protocol != val && msg.Account != val {
-				continue
+			if msg.Protocol == val || msg.Account == val {
+				if avatar := b.findAvatar(msg); avatar != "" {
+					msg.Avatar = avatar
+				}
+				break
 			}
-			if avatar, ok := b.findAvatar(msg); ok {
-				msg.Avatar = avatar
-			}
-			break
 		}
 	}
 
@@ -444,10 +444,10 @@ func (b *Bdiscord) webhookSend(msg *config.Message, webhookID, token string) (*d
 	return res, err
 }
 
-func (b *Bdiscord) findAvatar(m *config.Message) (string, bool) {
+func (b *Bdiscord) findAvatar(m *config.Message) string {
 	member, err := b.getGuildMemberByNick(m.Username)
 	if err != nil {
-		return "", false
+		return ""
 	}
-	return member.User.AvatarURL(""), true
+	return member.User.AvatarURL("")
 }

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -306,8 +306,6 @@ func (gw *Gateway) ignoreMessage(msg *config.Message) bool {
 }
 
 func (gw *Gateway) modifyUsername(msg *config.Message, dest *bridge.Bridge) string {
-	br := gw.Bridges[msg.Account]
-	msg.Protocol = br.Protocol
 	if dest.GetBool("StripNick") {
 		re := regexp.MustCompile("[^a-zA-Z0-9]+")
 		msg.Username = re.ReplaceAllString(msg.Username, "")
@@ -315,6 +313,7 @@ func (gw *Gateway) modifyUsername(msg *config.Message, dest *bridge.Bridge) stri
 	nick := dest.GetString("RemoteNickFormat")
 
 	// loop to replace nicks
+	br := gw.Bridges[msg.Account]
 	for _, outer := range br.GetStringSlice2D("ReplaceNicks") {
 		search := outer[0]
 		replace := outer[1]

--- a/gateway/router.go
+++ b/gateway/router.go
@@ -132,6 +132,9 @@ func (r *Router) handleReceive() {
 		r.handleEventFailure(&msg)
 		r.handleEventRejoinChannels(&msg)
 
+		// Set message protocol based on the account it came from
+		msg.Protocol = r.getBridge(msg.Account).Protocol
+
 		filesHandled := false
 		for _, gw := range r.Gateways {
 			// record all the message ID's of the different bridges

--- a/matterbridge.toml.sample
+++ b/matterbridge.toml.sample
@@ -724,6 +724,12 @@ Server="yourservername"
 #OPTIONAL (default false)
 ShowEmbeds=false
 
+#Show Discord avatars of remote users with matching names
+#This only works for webhooks & if the source message has no avatar
+#
+#OPTIONAL (default empty)
+UseLocalAvatar=["irc"]
+
 #Shows the username instead of the server nickname
 #OPTIONAL (default false)
 UseUserName=false


### PR DESCRIPTION
This adds a new `UseRemoteAvatar bool` setting that makes it possible for gateways to procure avatars from destination bridges.

**Use case**

Messages from IRC use a static avatar on Discord. Sometimes a user will be on both IRC and Discord, so we could try to use the matching Discord user's avatar instead.

**How this fits in**

If a `msg.Avatar` is equal to `"UseRemoteAvatar"`, the gateway will ask the destination bridge to find an avatar based on the source message.

If the destination bridge doesn't implement `FindAvatar`, or `FindAvatar` was unsuccessful, it will drop back onto `IconURL`.

**Other notes**

I've left notes in the code about whether or not we want debug output. I suspect it will be very spammy for existing bridges that don't support `UseRemoteAvatar`. If we don't want debug messages, I can simplify this code to be less nested.

An alternate way to do this, without using an interface, is to move this logic to `Bdiscord`. Then in `gateway.go` we can just set avatar to `""` if the destination bridge is not discord. Would that be better?