### PR TITLE
Be less lossy when throttling IRC messages

### DIFF
--- a/bridge/irc/irc.go
+++ b/bridge/irc/irc.go
@@ -167,12 +167,8 @@ func (b *Birc) Send(msg config.Message) (string, error) {
 			return "", nil
 		}
 
-		b.Local <- config.Message{
-			Text:     msgLines[i],
-			Username: msg.Username,
-			Channel:  msg.Channel,
-			Event:    msg.Event,
-		}
+		msg.Text = msgLines[i]
+		b.Local <- msg
 	}
 	return "", nil
 }


### PR DESCRIPTION
This doesn't actually fix anything, but should make the IRC side more predictable.

Note that msg.Text and chucking it through a chan is OK: https://play.golang.org/p/MTfT3YSsgPX