### PR TITLE
Fix #1039: messages sent to Slack being synced back

### DIFF
--- a/bridge/slack/slack.go
+++ b/bridge/slack/slack.go
@@ -498,7 +498,8 @@ func (b *Bslack) prepareMessageOptions(msg *config.Message) []slack.MsgOption {
 
 	var attachments []slack.Attachment
 	// add a callback ID so we can see we created it
-	attachments = append(attachments, slack.Attachment{CallbackID: "matterbridge_" + b.uuid})
+	const zeroWidthSpace = "\u200b"
+	attachments = append(attachments, slack.Attachment{CallbackID: "matterbridge_" + b.uuid, Fallback: zeroWidthSpace})
 	// add file attachments
 	attachments = append(attachments, b.createAttach(msg.Extra)...)
 	// add slack attachments (from another slack bridge)


### PR DESCRIPTION
This is a regression from https://github.com/42wim/matterbridge/pull/581#issuecomment-562937576

Behaves the same as https://github.com/matterbridge/slack/commit/95190f11bfb6405b0394b75a29bd1c1bb91f553e

Easiest fix without changing upstream is to set the fallback string to a zero width space.

Fixes #1039