### PR TITLE
slack: use blocks not attachments

### DIFF
--- a/bridge/slack/handlers.go
+++ b/bridge/slack/handlers.go
@@ -124,10 +124,16 @@ func (b *Bslack) skipMessageEvent(ev *slack.MessageEvent) bool {
 		}
 	}
 
+	// Check for our callback ID
+	hasOurCallbackID := false
+	if len(ev.Blocks.BlockSet) == 1 {
+		block, ok := ev.Blocks.BlockSet[0].(*slack.SectionBlock)
+		hasOurCallbackID = ok && block.BlockID == "matterbridge_"+b.uuid
+	}
+
 	// Skip any messages that we made ourselves or from 'slackbot' (see #527).
 	if ev.Username == sSlackBotUser ||
-		(b.rtm != nil && ev.Username == b.si.User.Name) ||
-		(len(ev.Attachments) > 0 && ev.Attachments[0].CallbackID == "matterbridge_"+b.uuid) {
+		(b.rtm != nil && ev.Username == b.si.User.Name) || hasOurCallbackID {
 		return true
 	}
 


### PR DESCRIPTION
This removes the extra space below messages, as shown in ![space](https://user-images.githubusercontent.com/923242/77235190-a3359980-6bab-11ea-8b7b-697d730ae5c1.png)
