### PR TITLE
Strip extra info from emotes (discord)

### DIFF
--- a/bridge/discord/handlers.go
+++ b/bridge/discord/handlers.go
@@ -119,6 +119,9 @@ func (b *Bdiscord) messageCreate(s *discordgo.Session, m *discordgo.MessageCreat
 		rmsg.Event = config.EventUserAction
 	}
 
+	// Replace emotes
+	rmsg.Text = replaceEmotes(rmsg.Text)
+
 	b.Log.Debugf("<= Sending message from %s on %s to gateway", m.Author.Username, b.Account)
 	b.Log.Debugf("<= Message is %#v", rmsg)
 	b.Remote <- rmsg

--- a/bridge/discord/helpers.go
+++ b/bridge/discord/helpers.go
@@ -137,6 +137,7 @@ var (
 	// See https://discordapp.com/developers/docs/reference#message-formatting.
 	channelMentionRE = regexp.MustCompile("<#[0-9]+>")
 	userMentionRE    = regexp.MustCompile("@[^@\n]{1,32}")
+	emoteRE          = regexp.MustCompile(`<a?(:\w+:)\d+>`)
 )
 
 func (b *Bdiscord) replaceChannelMentions(text string) string {
@@ -180,6 +181,10 @@ func (b *Bdiscord) replaceUserMentions(text string) string {
 		return strings.Replace(match, "@"+username, member.User.Mention(), 1)
 	}
 	return userMentionRE.ReplaceAllStringFunc(text, replaceUserMentionFunc)
+}
+
+func replaceEmotes(text string) string {
+	return emoteRE.ReplaceAllString(text, "$1")
 }
 
 func (b *Bdiscord) replaceAction(text string) (string, bool) {


### PR DESCRIPTION
**Discord**

```
Before (static): :facepalm:
After (animated): :crabrave:
```

![image](https://user-images.githubusercontent.com/923242/77238965-65496d00-6bcd-11ea-854b-b734d1d6e4cc.png)

**Other bridges**: slack

![image](https://user-images.githubusercontent.com/923242/77238971-6d091180-6bcd-11ea-8021-63e61716036e.png)

**Other bridges**: telegram

![Screenshot_20200321-234423](https://user-images.githubusercontent.com/923242/77239048-02a4a100-6bce-11ea-8996-6393f1f0eb2c.png)

**Additional information**

This has been tested in another bridge and it works fine ([commit](https://github.com/qaisjp/go-discord-irc/commit/6f975740e0a427d110683bbec589e641ce91d721)).