### PR TITLE
Add support for build tags

### DIFF
--- a/gateway/bridgemap/api.go
+++ b/gateway/bridgemap/api.go
@@ -1,0 +1,11 @@
+// +build !noapi
+
+package bridgemap
+
+import (
+	"github.com/42wim/matterbridge/bridge/api"
+)
+
+func init() {
+	FullMap["api"] = api.New
+}

--- a/gateway/bridgemap/bdiscord.go
+++ b/gateway/bridgemap/bdiscord.go
@@ -1,0 +1,12 @@
+// +build !nodiscord
+
+package bridgemap
+
+import (
+	bdiscord "github.com/42wim/matterbridge/bridge/discord"
+)
+
+func init() {
+	FullMap["discord"] = bdiscord.New
+	UserTypingSupport["discord"] = struct{}{}
+}

--- a/gateway/bridgemap/bgitter.go
+++ b/gateway/bridgemap/bgitter.go
@@ -1,0 +1,11 @@
+// +build !nogitter
+
+package bridgemap
+
+import (
+	bgitter "github.com/42wim/matterbridge/bridge/gitter"
+)
+
+func init() {
+	FullMap["gitter"] = bgitter.New
+}

--- a/gateway/bridgemap/birc.go
+++ b/gateway/bridgemap/birc.go
@@ -1,0 +1,11 @@
+// +build !noirc
+
+package bridgemap
+
+import (
+	birc "github.com/42wim/matterbridge/bridge/irc"
+)
+
+func init() {
+	FullMap["irc"] = birc.New
+}

--- a/gateway/bridgemap/bkeybase.go
+++ b/gateway/bridgemap/bkeybase.go
@@ -1,0 +1,11 @@
+// +build !nokeybase
+
+package bridgemap
+
+import (
+	bkeybase "github.com/42wim/matterbridge/bridge/keybase"
+)
+
+func init() {
+	FullMap["keybase"] = bkeybase.New
+}

--- a/gateway/bridgemap/bmatrix.go
+++ b/gateway/bridgemap/bmatrix.go
@@ -1,0 +1,11 @@
+// +build !nomatrix
+
+package bridgemap
+
+import (
+	bmatrix "github.com/42wim/matterbridge/bridge/matrix"
+)
+
+func init() {
+	FullMap["matrix"] = bmatrix.New
+}

--- a/gateway/bridgemap/bmattermost.go
+++ b/gateway/bridgemap/bmattermost.go
@@ -1,0 +1,11 @@
+// +build !nomattermost
+
+package bridgemap
+
+import (
+	bmattermost "github.com/42wim/matterbridge/bridge/mattermost"
+)
+
+func init() {
+	FullMap["mattermost"] = bmattermost.New
+}

--- a/gateway/bridgemap/bmsteams.go
+++ b/gateway/bridgemap/bmsteams.go
@@ -1,0 +1,11 @@
+// +build !nomsteams
+
+package bridgemap
+
+import (
+	bmsteams "github.com/42wim/matterbridge/bridge/msteams"
+)
+
+func init() {
+	FullMap["msteams"] = bmsteams.New
+}

--- a/gateway/bridgemap/bridgemap.go
+++ b/gateway/bridgemap/bridgemap.go
@@ -2,47 +2,9 @@ package bridgemap
 
 import (
 	"github.com/42wim/matterbridge/bridge"
-	"github.com/42wim/matterbridge/bridge/api"
-	bdiscord "github.com/42wim/matterbridge/bridge/discord"
-	bgitter "github.com/42wim/matterbridge/bridge/gitter"
-	birc "github.com/42wim/matterbridge/bridge/irc"
-	bkeybase "github.com/42wim/matterbridge/bridge/keybase"
-	bmatrix "github.com/42wim/matterbridge/bridge/matrix"
-	bmattermost "github.com/42wim/matterbridge/bridge/mattermost"
-	bmsteams "github.com/42wim/matterbridge/bridge/msteams"
-	brocketchat "github.com/42wim/matterbridge/bridge/rocketchat"
-	bslack "github.com/42wim/matterbridge/bridge/slack"
-	bsshchat "github.com/42wim/matterbridge/bridge/sshchat"
-	bsteam "github.com/42wim/matterbridge/bridge/steam"
-	btelegram "github.com/42wim/matterbridge/bridge/telegram"
-	bwhatsapp "github.com/42wim/matterbridge/bridge/whatsapp"
-	bxmpp "github.com/42wim/matterbridge/bridge/xmpp"
-	bzulip "github.com/42wim/matterbridge/bridge/zulip"
 )
 
 var (
-	FullMap = map[string]bridge.Factory{
-		"api":          api.New,
-		"discord":      bdiscord.New,
-		"gitter":       bgitter.New,
-		"irc":          birc.New,
-		"mattermost":   bmattermost.New,
-		"matrix":       bmatrix.New,
-		"rocketchat":   brocketchat.New,
-		"slack-legacy": bslack.NewLegacy,
-		"slack":        bslack.New,
-		"sshchat":      bsshchat.New,
-		"steam":        bsteam.New,
-		"telegram":     btelegram.New,
-		"whatsapp":     bwhatsapp.New,
-		"xmpp":         bxmpp.New,
-		"zulip":        bzulip.New,
-		"keybase":      bkeybase.New,
-		"msteams":      bmsteams.New,
-	}
-
-	UserTypingSupport = map[string]struct{}{
-		"slack":   {},
-		"discord": {},
-	}
+	FullMap           = map[string]bridge.Factory{}
+	UserTypingSupport = map[string]struct{}{}
 )

--- a/gateway/bridgemap/brocketchat.go
+++ b/gateway/bridgemap/brocketchat.go
@@ -1,0 +1,11 @@
+// +build !norocketchat
+
+package bridgemap
+
+import (
+	brocketchat "github.com/42wim/matterbridge/bridge/rocketchat"
+)
+
+func init() {
+	FullMap["rocketchat"] = brocketchat.New
+}

--- a/gateway/bridgemap/bslack.go
+++ b/gateway/bridgemap/bslack.go
@@ -1,0 +1,13 @@
+// +build !noslack
+
+package bridgemap
+
+import (
+	bslack "github.com/42wim/matterbridge/bridge/slack"
+)
+
+func init() {
+	FullMap["slack-legacy"] = bslack.NewLegacy
+	FullMap["slack"] = bslack.New
+	UserTypingSupport["slack"] = struct{}{}
+}

--- a/gateway/bridgemap/bsshchat.go
+++ b/gateway/bridgemap/bsshchat.go
@@ -1,0 +1,11 @@
+// +build !nosshchat
+
+package bridgemap
+
+import (
+	bsshchat "github.com/42wim/matterbridge/bridge/sshchat"
+)
+
+func init() {
+	FullMap["sshchat"] = bsshchat.New
+}

--- a/gateway/bridgemap/bsteam.go
+++ b/gateway/bridgemap/bsteam.go
@@ -1,0 +1,11 @@
+// +build !nosteam
+
+package bridgemap
+
+import (
+	bsteam "github.com/42wim/matterbridge/bridge/steam"
+)
+
+func init() {
+	FullMap["steam"] = bsteam.New
+}

--- a/gateway/bridgemap/btelegram.go
+++ b/gateway/bridgemap/btelegram.go
@@ -1,0 +1,11 @@
+// +build !notelegram
+
+package bridgemap
+
+import (
+	btelegram "github.com/42wim/matterbridge/bridge/telegram"
+)
+
+func init() {
+	FullMap["telegram"] = btelegram.New
+}

--- a/gateway/bridgemap/bwhatsapp.go
+++ b/gateway/bridgemap/bwhatsapp.go
@@ -1,0 +1,11 @@
+// +build !nowhatsapp
+
+package bridgemap
+
+import (
+	bwhatsapp "github.com/42wim/matterbridge/bridge/whatsapp"
+)
+
+func init() {
+	FullMap["whatsapp"] = bwhatsapp.New
+}

--- a/gateway/bridgemap/bxmpp.go
+++ b/gateway/bridgemap/bxmpp.go
@@ -1,0 +1,11 @@
+// +build !noxmpp
+
+package bridgemap
+
+import (
+	bxmpp "github.com/42wim/matterbridge/bridge/xmpp"
+)
+
+func init() {
+	FullMap["xmpp"] = bxmpp.New
+}

--- a/gateway/bridgemap/bzulip.go
+++ b/gateway/bridgemap/bzulip.go
@@ -1,0 +1,11 @@
+// +build !nozulip
+
+package bridgemap
+
+import (
+	bzulip "github.com/42wim/matterbridge/bridge/zulip"
+)
+
+func init() {
+	FullMap["zulip"] = bzulip.New
+}


### PR DESCRIPTION
> [gitter] <hamoid> I see. Thank you. Is it possible to make a build choosing with platforms to support? (just curious)

This feature makes that possible. I just want to see if I could do it, I don't really care about this being merged, but it works if you want it!

By default all bridges are available.

You can turn off certain bridges by providing
e.g. "withoutdiscord" as a build tag.

    go build -tags withoutmsteams,withoutapi

**Example config**

<details><summary>(simple with just discord, slack and telegram)</summary>

```toml
[telegram]
[telegram.test]
Token="tok"
RemoteNickFormat="[{PROTOCOL}] <{NICK}> "

[discord]
[discord.mta]
Token="tok"
Server="id"
RemoteNickFormat="{NICK}"
WebhookURL="tok"
ShowEmbeds=true

[slack]
[slack.mta]
Token="tok"
RemoteNickFormat="{NICK}"

[[gateway]]
name="mta.test"
enable=true

[[gateway.inout]]
account="slack.mta"
channel="test"

[[gateway.inout]]
account="discord.mta"
channel="test"

[[gateway.inout]]
account="telegram.test"
channel="-411596043"
```

</details>

**Example: without discord**
```
➜ go build -tags withoutdiscord
➜ ./matterbridge -debug
[0000]  INFO main:         Enabling debug logging.
[0000]  INFO main:         Running version 1.17.1-dev
[0000]  INFO main:         WARNING: THIS IS A DEVELOPMENT VERSION. Things may break.
[0000] FATAL gateway:      Incorrect protocol discord specified in gateway configuration discord.mta, exiting.
```

**Example: size with/without msteams**

```
➜ go build
➜ ls -lah matterbridge
-rwxr-xr-x  1 qaisjp  staff    61M 22 Mar 04:45 matterbridge

➜ go build --tags withoutmsteams
➜ ls -lah matterbridge
-rwxr-xr-x  1 qaisjp  staff    34M 22 Mar 04:45 matterbridge
```

**Example: without any tags**
```
➜ go build
➜ ./matterbridge
[2020-03-22T04:46:31Z]  INFO main:         Running version 1.17.1-dev
[2020-03-22T04:46:31Z]  INFO main:         WARNING: THIS IS A DEVELOPMENT VERSION. Things may break.
[2020-03-22T04:46:31Z]  INFO router:       Parsing gateway mta.test
[2020-03-22T04:46:31Z]  INFO router:       Starting bridge: discord.mta
[2020-03-22T04:46:31Z]  INFO discord:      Connecting
[2020-03-22T04:46:31Z]  INFO discord:      Connecting using webhookurl (for posting) and token
[2020-03-22T04:46:31Z]  INFO discord:      Connection succeeded
[2020-03-22T04:46:32Z]  INFO discord:      Can manage webhooks; will edit channel for global webhook on send
[2020-03-22T04:46:33Z]  INFO discord:      discord.mta: joining test (ID: testdiscord.mta)
[2020-03-22T04:46:33Z]  INFO router:       Starting bridge: telegram.test
[2020-03-22T04:46:33Z]  INFO telegram:     Connecting
[2020-03-22T04:46:33Z]  INFO telegram:     Connection succeeded
[2020-03-22T04:46:33Z]  INFO telegram:     telegram.test: joining -411596043 (ID: -411596043telegram.test)
[2020-03-22T04:46:33Z]  INFO router:       Starting bridge: slack.mta
[2020-03-22T04:46:33Z]  INFO slack:        Connecting using token
[2020-03-22T04:46:33Z]  INFO slack:        slack.mta: joining test (ID: testslack.mta)
[2020-03-22T04:46:33Z]  INFO main:         Gateway(s) started succesfully. Now relaying messages
```