### PR TITLE
Remove build dependencies from final image (multistage build)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,13 @@
-FROM alpine:edge
-ENTRYPOINT ["/bin/matterbridge"]
+FROM alpine:edge AS builder
 
 COPY . /go/src/github.com/42wim/matterbridge
-RUN apk update && apk add go git gcc musl-dev ca-certificates mailcap \
+RUN apk update && apk add go git gcc musl-dev \
         && cd /go/src/github.com/42wim/matterbridge \
         && export GOPATH=/go \
         && go get \
-        && go build -x -ldflags "-X main.githash=$(git log --pretty=format:'%h' -n 1)" -o /bin/matterbridge \
-        && rm -rf /go \
-        && apk del --purge git go gcc musl-dev
+        && go build -x -ldflags "-X main.githash=$(git log --pretty=format:'%h' -n 1)" -o /bin/matterbridge
+
+FROM alpine:edge
+RUN apk --no-cache add ca-certificates mailcap
+COPY --from=builder /bin/matterbridge /bin/matterbridge
+ENTRYPOINT ["/bin/matterbridge"]


### PR DESCRIPTION
This multistage build takes the resulting image size down from 346MB to
90MB.