### PR TITLE
set rmsg.Event in RocketChat bridge

### DIFF
--- a/bridge/rocketchat/handlers.go
+++ b/bridge/rocketchat/handlers.go
@@ -41,16 +41,16 @@ func (b *Brocketchat) handleRocketHook(messages chan *config.Message) {
 
 func (b *Brocketchat) handleStatusEvent(ev models.Message, rmsg *config.Message) bool {
 	switch ev.Type {
-		case "":
-			// this is a normal message, no processing needed
-			// return true so the message is not dropped
-			return true
-		case sUserJoined, sUserLeft:
-			rmsg.Event = config.EventJoinLeave
-			return true
-		case sRoomChangedTopic:
-			rmsg.Event = config.EventTopicChange
-			return true
+	case "":
+		// this is a normal message, no processing needed
+		// return true so the message is not dropped
+		return true
+	case sUserJoined, sUserLeft:
+		rmsg.Event = config.EventJoinLeave
+		return true
+	case sRoomChangedTopic:
+		rmsg.Event = config.EventTopicChange
+		return true
 	}
 	b.Log.Debugf("Dropping message with unknown type: %s", ev.Type)
 	return false

--- a/bridge/rocketchat/rocketchat.go
+++ b/bridge/rocketchat/rocketchat.go
@@ -29,6 +29,12 @@ type Brocketchat struct {
 	sync.RWMutex
 }
 
+const (
+	sUserJoined = "uj"
+	sUserLeft = "ul"
+	sRoomChangedTopic = "room_changed_topic"
+)
+
 func New(cfg *bridge.Config) bridge.Bridger {
 	newCache, err := lru.New(100)
 	if err != nil {

--- a/bridge/rocketchat/rocketchat.go
+++ b/bridge/rocketchat/rocketchat.go
@@ -30,8 +30,8 @@ type Brocketchat struct {
 }
 
 const (
-	sUserJoined = "uj"
-	sUserLeft = "ul"
+	sUserJoined       = "uj"
+	sUserLeft         = "ul"
 	sRoomChangedTopic = "room_changed_topic"
 )
 


### PR DESCRIPTION
Note that this requires the following pull request in the matterbridge/Rocket.Chat.Go.SDK project to be merged (and CI is probably going to fail until then): https://github.com/matterbridge/Rocket.Chat.Go.SDK/pull/2

This pull request properly sets the events `EventJoinLeave` and `EventTopicChange` for messages from the RocketChat bridge and drops messages which are neither one of those events nor plain messages. (Is this behavior desirable? Otherwise all messages like changing the role of a user in a channel are relayed without a corresponding Event and are thus spammed in the connected bridges)

I haven't found guidelines for contributers so if I should change anything or "sign" a CLA or whatever let me know.