### PR TITLE
fix the behavior of ShowTopicChange and SyncTopic

### DIFF
--- a/gateway/handlers.go
+++ b/gateway/handlers.go
@@ -179,7 +179,7 @@ func (gw *Gateway) ignoreEvent(event string, dest *bridge.Bridge) bool {
 		}
 	case config.EventTopicChange:
 		// only relay topic change when used in some way on other side
-		if dest.GetBool("ShowTopicChange") && dest.GetBool("SyncTopic") {
+		if !dest.GetBool("ShowTopicChange") && !dest.GetBool("SyncTopic") {
 			return true
 		}
 	}


### PR DESCRIPTION
Currently, the "topic_change" events are ignored if both, `ShowTopicChange` and `SyncTopic` are set, and forwarded otherwise. This pull requests changes the behavior such that the events are only forwarded if one of those two config options is set to true and ignored otherwise.