### PR TITLE
Implement User Avatar spoofing of XMPP users

### DIFF
--- a/bridge/xmpp/handler.go
+++ b/bridge/xmpp/handler.go
@@ -1,0 +1,34 @@
+package bxmpp
+
+import (
+	"github.com/42wim/matterbridge/bridge/config"
+	"github.com/42wim/matterbridge/bridge/helper"
+	"github.com/matterbridge/go-xmpp"
+)
+
+// handleDownloadAvatar downloads the avatar of userid from channel
+// sends a EVENT_AVATAR_DOWNLOAD message to the gateway if successful.
+// logs an error message if it fails
+func (b *Bxmpp) handleDownloadAvatar(avatar xmpp.AvatarData) {
+	rmsg := config.Message{
+		Username: "system",
+		Text:     "avatar",
+		Channel:  b.parseChannel(avatar.From),
+		Account:  b.Account,
+		UserID:   avatar.From,
+		Event:    config.EventAvatarDownload,
+		Extra:    make(map[string][]interface{}),
+	}
+	if _, ok := b.avatarMap[avatar.From]; !ok {
+		b.Log.Debugf("Avatar.From: %s", avatar.From)
+
+		err := helper.HandleDownloadSize(b.Log, &rmsg, avatar.From+".png", int64(len(avatar.Data)), b.General)
+		if err != nil {
+			b.Log.Error(err)
+			return
+		}
+		helper.HandleDownloadData(b.Log, &rmsg, avatar.From+".png", rmsg.Text, "", &avatar.Data, b.General)
+		b.Log.Debugf("Avatar download complete")
+		b.Remote <- rmsg
+	}
+}

--- a/bridge/xmpp/helpers.go
+++ b/bridge/xmpp/helpers.go
@@ -6,12 +6,13 @@ import (
 	"github.com/42wim/matterbridge/bridge/config"
 )
 
+var pathRegex = regexp.MustCompile("[^a-zA-Z0-9]+")
+
 // GetAvatar constructs a URL for a given user-avatar if it is available in the cache.
 func getAvatar(av map[string]string, userid string, general *config.Protocol) string {
 	if hash, ok := av[userid]; ok {
 		// NOTE: This does not happen in bridge/helper/helper.go but messes up XMPP
-		reg := regexp.MustCompile("[^a-zA-Z0-9]+")
-		id := reg.ReplaceAllString(userid, "_")
+		id := pathRegex.ReplaceAllString(userid, "_")
 		return general.MediaServerDownload + "/" + hash + "/" + id + ".png"
 	}
 	return ""

--- a/bridge/xmpp/helpers.go
+++ b/bridge/xmpp/helpers.go
@@ -1,0 +1,29 @@
+package bxmpp
+
+import (
+	"regexp"
+
+	"github.com/42wim/matterbridge/bridge/config"
+)
+
+// GetAvatar constructs a URL for a given user-avatar if it is available in the cache.
+func getAvatar(av map[string]string, userid string, general *config.Protocol) string {
+	if hash, ok := av[userid]; ok {
+		// NOTE: This does not happen in bridge/helper/helper.go but messes up XMPP
+		reg := regexp.MustCompile("[^a-zA-Z0-9]+")
+		id := reg.ReplaceAllString(userid, "_")
+		return general.MediaServerDownload + "/" + hash + "/" + id + ".png"
+	}
+	return ""
+}
+
+func (b *Bxmpp) cacheAvatar(msg *config.Message) string {
+	fi := msg.Extra["file"][0].(config.FileInfo)
+	/* if we have a sha we have successfully uploaded the file to the media server,
+	so we can now cache the sha */
+	if fi.SHA != "" {
+		b.Log.Debugf("Added %s to %s in avatarMap", fi.SHA, msg.UserID)
+		b.avatarMap[msg.UserID] = fi.SHA
+	}
+	return ""
+}

--- a/gateway/handlers.go
+++ b/gateway/handlers.go
@@ -169,7 +169,7 @@ func (gw *Gateway) ignoreEvent(event string, dest *bridge.Bridge) bool {
 	switch event {
 	case config.EventAvatarDownload:
 		// Avatar downloads are only relevant for telegram and mattermost for now
-		if dest.Protocol != "mattermost" && dest.Protocol != "telegram" {
+		if dest.Protocol != "mattermost" && dest.Protocol != "telegram" && dest.Protocol != "xmpp" {
 			return true
 		}
 	case config.EventJoinLeave:


### PR DESCRIPTION
This PR adds the functionality to spoof the avatar of XMPP users in different bridges. This solves #1024.