### PR TITLE
Check if XMPP users support User Avatars

### DIFF
--- a/bridge/xmpp/handler.go
+++ b/bridge/xmpp/handler.go
@@ -32,3 +32,13 @@ func (b *Bxmpp) handleDownloadAvatar(avatar xmpp.AvatarData) {
 		b.Remote <- rmsg
 	}
 }
+
+func (b *Bxmpp) handleDisco(items xmpp.DiscoItems) {
+	if discoSupportsAvatar(items.Items) {
+		b.Log.Debugf("%s supports avatars", items.Jid)
+		b.avatarAvailability[items.Jid] = avatarAvailable
+	} else {
+		b.Log.Debugf("%s does not support avatars", items.Jid)
+		b.avatarAvailability[items.Jid] = avatarUnavailable
+	}
+}

--- a/bridge/xmpp/helpers.go
+++ b/bridge/xmpp/helpers.go
@@ -1,6 +1,7 @@
 package bxmpp
 
 import (
+	"fmt"
 	"regexp"
 
 	"github.com/42wim/matterbridge/bridge/config"
@@ -30,7 +31,7 @@ func (b *Bxmpp) cacheAvatar(msg *config.Message) string {
 	return ""
 }
 
-func discoSupportsAvatar(items []*xmpp.DiscoItems) bool {
+func discoSupportsAvatar(items []xmpp.DiscoItem) bool {
 	for _, item := range items {
 		if item.Node == xmpp.XMPPNS_AVATAR_PEP_DATA {
 			return true
@@ -38,14 +39,4 @@ func discoSupportsAvatar(items []*xmpp.DiscoItems) bool {
 	}
 
 	return false
-}
-
-func (b *Bxmpp) handleDisco(items xmpp.DiscoItems) {
-	if discoSupportsAvatar(items) {
-		b.Log.Debugf("%s supports avatars", items.Jid)
-		b.avatarAvailability[items.Jid] = avatarAvailable
-	} else {
-		b.Log.Debugf("%s does not support avatars", items.Jid)
-		b.avatarAvailability[items.Jid] = avatarUnavailable
-	}
 }

--- a/bridge/xmpp/helpers.go
+++ b/bridge/xmpp/helpers.go
@@ -4,6 +4,7 @@ import (
 	"regexp"
 
 	"github.com/42wim/matterbridge/bridge/config"
+	"github.com/matterbridge/go-xmpp"
 )
 
 var pathRegex = regexp.MustCompile("[^a-zA-Z0-9]+")
@@ -27,4 +28,24 @@ func (b *Bxmpp) cacheAvatar(msg *config.Message) string {
 		b.avatarMap[msg.UserID] = fi.SHA
 	}
 	return ""
+}
+
+func discoSupportsAvatar(items []*xmpp.DiscoItems) bool {
+	for _, item := range items {
+		if item.Node == xmpp.XMPPNS_AVATAR_PEP_DATA {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (b *Bxmpp) handleDisco(items xmpp.DiscoItems) {
+	if discoSupportsAvatar(items) {
+		b.Log.Debugf("%s supports avatars", items.Jid)
+		b.avatarAvailability[items.Jid] = avatarAvailable
+	} else {
+		b.Log.Debugf("%s does not support avatars", items.Jid)
+		b.avatarAvailability[items.Jid] = avatarUnavailable
+	}
 }

--- a/bridge/xmpp/xmpp.go
+++ b/bridge/xmpp/xmpp.go
@@ -16,10 +16,8 @@ import (
 )
 
 type avatarAvailability int
-
 const (
-	avatarDiscoSent avatarAvailability = iota
-	avatarAvailable
+	avatarAvailable avatarAvailability = iota
 	avatarUnavailable
 )
 
@@ -254,7 +252,7 @@ func (b *Bxmpp) handleXMPP() error {
 				if !sok {
 					b.Log.Debugf("Sending disco to %s", v.Remote)
 					b.xc.DiscoverEntityItems(v.Remote)
-					b.avatarAvailability[v.Remote] = avatarDiscoSent
+					b.avatarAvailability[v.Remote] = avatarUnavailable
 				} else if state == avatarAvailable {
 					avatar = getAvatar(b.avatarMap, v.Remote, b.General)
 					if avatar == "" {

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/matterbridge/Rocket.Chat.Go.SDK v0.0.0-20200411204219-d5c18ce75048
 	github.com/matterbridge/discordgo v0.18.1-0.20200308151012-aa40f01cbcc3
 	github.com/matterbridge/emoji v2.1.1-0.20191117213217-af507f6b02db+incompatible
-	github.com/matterbridge/go-xmpp v0.0.0-20200329150250-5812999b292b
+	github.com/matterbridge/go-xmpp v0.0.0-20200418162626-e69b0b8696ef
 	github.com/matterbridge/gomatrix v0.0.0-20200209224845-c2104d7936a6
 	github.com/matterbridge/gozulipbot v0.0.0-20190212232658-7aa251978a18
 	github.com/matterbridge/logrus-prefixed-formatter v0.0.0-20180806162718-01618749af61

--- a/go.sum
+++ b/go.sum
@@ -132,6 +132,8 @@ github.com/matterbridge/emoji v2.1.1-0.20191117213217-af507f6b02db+incompatible 
 github.com/matterbridge/emoji v2.1.1-0.20191117213217-af507f6b02db+incompatible/go.mod h1:igE6rUAn3jai2wCdsjFHfhUoekjrFthoEjFObKKwSb4=
 github.com/matterbridge/go-xmpp v0.0.0-20200329150250-5812999b292b h1:ZYI2HCj9zPzI4Si1ouSOi/ImA2xSQLUCJPQsLWr8FE0=
 github.com/matterbridge/go-xmpp v0.0.0-20200329150250-5812999b292b/go.mod h1:ECDRehsR9TYTKCAsRS8/wLeOk6UUqDydw47ln7wG41Q=
+github.com/matterbridge/go-xmpp v0.0.0-20200418162626-e69b0b8696ef h1:CDIIh3ZViXddwWh9vctOmOOQPXhWeuHdGnwNkPc5JtE=
+github.com/matterbridge/go-xmpp v0.0.0-20200418162626-e69b0b8696ef/go.mod h1:ECDRehsR9TYTKCAsRS8/wLeOk6UUqDydw47ln7wG41Q=
 github.com/matterbridge/gomatrix v0.0.0-20200209224845-c2104d7936a6 h1:Kl65VJv38HjYFnnwH+MP6Z8hcJT5UHuSpHVU5vW1HH0=
 github.com/matterbridge/gomatrix v0.0.0-20200209224845-c2104d7936a6/go.mod h1:+jWeaaUtXQbBRdKYWfjW6JDDYiI2XXE+3NnTjW5kg8g=
 github.com/matterbridge/gozulipbot v0.0.0-20190212232658-7aa251978a18 h1:fLhwXtWGtfTgZVxHG1lcKjv+re7dRwyyuYFNu69xdho=


### PR DESCRIPTION
As requested per [#1024](https://github.com/42wim/matterbridge/issues/1024#issuecomment-614878273) This PR checks whether a given XMPP user supports avatars before trying to request the data.

This PR is not yet tested or finished as it requires another patch to go-xmpp. Once this PR is not a WIP anymore, I will squash the commits.

**EDIT**: PR has been created [upstream](https://github.com/mattn/go-xmpp/pull/124). I also created one for the [go-xmpp fork](https://github.com/matterbridge/go-xmpp/pull/6)