### PR TITLE
Add JoinDelay option (irc). Fixes #1084

### DIFF
--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -4,6 +4,7 @@ import (
 	"log"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/42wim/matterbridge/bridge/config"
 	"github.com/sirupsen/logrus"
@@ -74,6 +75,7 @@ func (b *Bridge) joinChannels(channels map[string]config.ChannelInfo, exists map
 	for ID, channel := range channels {
 		if !exists[ID] {
 			b.Log.Infof("%s: joining %s (ID: %s)", b.Account, channel.Name, ID)
+			time.Sleep(time.Duration(b.GetInt("JoinDelay")) * time.Millisecond)
 			err := b.JoinChannel(channel)
 			if err != nil {
 				return err

--- a/bridge/config/config.go
+++ b/bridge/config/config.go
@@ -89,6 +89,7 @@ type Protocol struct {
 	IgnoreNicks            string // all protocols
 	IgnoreMessages         string // all protocols
 	Jid                    string // xmpp
+	JoinDelay              string // all protocols
 	Label                  string // all protocols
 	Login                  string // mattermost, matrix
 	MediaDownloadBlackList []string

--- a/matterbridge.toml.sample
+++ b/matterbridge.toml.sample
@@ -177,6 +177,12 @@ StripNick=false
 #OPTIONAL (default false)
 ShowTopicChange=false
 
+#Delay in milliseconds between channel joins
+#Only useful when you have a LOT of channels to join
+#See https://github.com/42wim/matterbridge/issues/1084
+#OPTIONAL (default 0)
+JoinDelay=0
+
 ###################################################################
 #XMPP section
 ###################################################################


### PR DESCRIPTION
Add support for setting a delay in milliseconds between channel JOINs.
(works for every bridge, but only relevant for IRC)