### PR TITLE
Prevent Re-requesting XMPP Avatar Data

### DIFF
--- a/bridge/xmpp/xmpp.go
+++ b/bridge/xmpp/xmpp.go
@@ -24,14 +24,16 @@ type Bxmpp struct {
 	connected bool
 	sync.RWMutex
 
-	avatarMap map[string]string
+	avatarAvailability map[string]bool
+	avatarMap          map[string]string
 }
 
 func New(cfg *bridge.Config) bridge.Bridger {
 	return &Bxmpp{
-		Config:    cfg,
-		xmppMap:   make(map[string]string),
-		avatarMap: make(map[string]string),
+		Config:             cfg,
+		xmppMap:            make(map[string]string),
+		avatarAvailability: make(map[string]bool),
+		avatarMap:          make(map[string]string),
 	}
 }
 
@@ -237,10 +239,14 @@ func (b *Bxmpp) handleXMPP() error {
 					event = config.EventTopicChange
 				}
 
-				avatar := getAvatar(b.avatarMap, v.Remote, b.General)
-				if avatar == "" {
+				available, sok := b.avatarAvailability[v.Remote]
+				avatar := ""
+				if !sok {
 					b.Log.Debugf("Requesting avatar data")
+					b.avatarAvailability[v.Remote] = false
 					b.xc.AvatarRequestData(v.Remote)
+				} else if available {
+					avatar = getAvatar(b.avatarMap, v.Remote, b.General)
 				}
 
 				msgID := v.ID
@@ -271,6 +277,8 @@ func (b *Bxmpp) handleXMPP() error {
 			}
 		case xmpp.AvatarData:
 			b.handleDownloadAvatar(v)
+			b.avatarAvailability[v.From] = true
+			b.Log.Debugf("Avatar for %s is now available", v.From)
 		case xmpp.Presence:
 			// Do nothing.
 		}


### PR DESCRIPTION
This PR is another version of #1092 . This version does not discover what a user in a MUC supports, but just requests avatar data anyway. If we get a response: use it; if we don't: don't ask again.

The reason for this "alternate" version is that I cannot use #1092 on my prosody server (See the PR for more details). While #1092 would be the much more elegant way, this one is much simpler and is tested.

**EDIT**: Typo