### PR TITLE
Avoids invalid url when the user doesn't have an avatar

### DIFF
--- a/bridge/matrix/matrix.go
+++ b/bridge/matrix/matrix.go
@@ -372,6 +372,8 @@ func (b *Bmatrix) getAvatarURL(sender string) string {
 		return ""
 	}
 	url := strings.ReplaceAll(mxcURL, "mxc://", b.GetString("Server")+"/_matrix/media/r0/thumbnail/")
-	url += "?width=37&height=37&method=crop"
+	if url != "" {
+		url += "?width=37&height=37&method=crop"
+	}
 	return url
 }


### PR DESCRIPTION
When the user didn't have an avatar set in matrix, an invalid url was being created: `?width=37&height=37&method=crop`

This was causing errors when sending the message to rocket.chat:
```
panic: interface conversion: interface {} is nil, not map[string]interface {}                                                                                                                                                                 
                                                                                                                                                                                                                                              
goroutine 31 [running]:                                                                                                                                                                                                                       
github.com/matterbridge/Rocket.Chat.Go.SDK/realtime.(*Client).SendMessage(0xc00083e190, 0xc003760640, 0x12, 0xc0004d5800, 0x17)                                                                                                               
        /home/tfve/go/pkg/mod/github.com/matterbridge/!rocket.!chat.!go.!s!d!k@v0.0.0-20200411204219-d5c18ce75048/realtime/messages.go:44 +0x1f8                                                                                              
github.com/42wim/matterbridge/bridge/rocketchat.(*Brocketchat).Send(0xc0003226c0, 0xc003660ed0, 0x29, 0xc00027b330, 0xc, 0xc0004c62c0, 0x12, 0xc000389d60, 0x12, 0x1ce1de4, ...)                                                              
        /home/tfve/github_tfve/matterbridge/bridge/rocketchat/rocketchat.go:176 +0x6af                                                                                                                                                        
github.com/42wim/matterbridge/gateway.(*Gateway).SendMessage(0xc000322600, 0xc00012c1a0, 0xc000118f80, 0xc0003c2500, 0x0, 0x0, 0xc, 0xc000318060, 0x17, 0xc000318060)                                                                         
        /home/tfve/github_tfve/matterbridge/gateway/gateway.go:457 +0x6ae                                                                                                                                                                     
github.com/42wim/matterbridge/gateway.(*Gateway).handleMessage(0xc000322600, 0xc00012c1a0, 0xc000118f80, 0xc000118f00, 0xc003629100, 0xc0035de800)                                                                                            
        /home/tfve/github_tfve/matterbridge/gateway/handlers.go:226 +0x246                                                                                                                                                                    
github.com/42wim/matterbridge/gateway.(*Router).handleReceive(0xc0000bbcc0)                                                                                                                                                                   
        /home/tfve/github_tfve/matterbridge/gateway/router.go:152 +0x241                                                                                                                                                                      
created by github.com/42wim/matterbridge/gateway.(*Router).Start                                                                                                                                                                              
        /home/tfve/github_tfve/matterbridge/gateway/router.go:102 +0xa45                                                                                                                                                                      
```