### PR TITLE
Add an option to disable sending HTML to matrix. Fixes #1022

### DIFF
--- a/bridge/config/config.go
+++ b/bridge/config/config.go
@@ -84,6 +84,7 @@ type Protocol struct {
 	DisableWebPagePreview  bool   // telegram
 	EditSuffix             string // mattermost, slack, discord, telegram, gitter
 	EditDisable            bool   // mattermost, slack, discord, telegram, gitter
+	HTMLDisable            bool   // matrix
 	IconURL                string // mattermost, slack
 	IgnoreFailureOnStart   bool   // general
 	IgnoreNicks            string // all protocols

--- a/bridge/matrix/matrix.go
+++ b/bridge/matrix/matrix.go
@@ -124,6 +124,14 @@ func (b *Bmatrix) Send(msg config.Message) (string, error) {
 		return resp.EventID, err
 	}
 
+	if b.GetBool("HTMLDisable") {
+		resp, err := b.mc.SendText(channel, msg.Username+msg.Text)
+		if err != nil {
+			return "", err
+		}
+		return resp.EventID, err
+	}
+
 	username := html.EscapeString(msg.Username)
 	// check if we have a </tag>. if we have, we don't escape HTML. #696
 	if b.htmlTag.MatchString(msg.Username) {

--- a/matterbridge.toml.sample
+++ b/matterbridge.toml.sample
@@ -1209,6 +1209,11 @@ Password="yourpass"
 #OPTIONAL (default false)
 NoHomeServerSuffix=false
 
+#Whether to disable sending of HTML content to matrix
+#See https://github.com/42wim/matterbridge/issues/1022
+#OPTIONAL (default false)
+HTMLDisable=false
+
 ## RELOADABLE SETTINGS
 ## Settings below can be reloaded by editing the file
 


### PR DESCRIPTION
Add `HTMLDisable=true` to your matrix configuration to disable the sending of HTML content.