### PR TITLE
Update Dockerfile so inotify works

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,7 @@ RUN apk update && apk add go git gcc musl-dev \
 FROM alpine:edge
 RUN apk --no-cache add ca-certificates mailcap
 COPY --from=builder /bin/matterbridge /bin/matterbridge
+RUN mkdir /conf
+RUN touch /conf/matterbridge.toml
+RUN ln -sf /matterbridge.toml /conf/matterbridge.toml
 ENTRYPOINT ["/bin/matterbridge", "-conf", "/conf/matterbridge.toml"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,4 @@ RUN apk update && apk add go git gcc musl-dev \
 FROM alpine:edge
 RUN apk --no-cache add ca-certificates mailcap
 COPY --from=builder /bin/matterbridge /bin/matterbridge
-ENTRYPOINT ["/bin/matterbridge"]
+ENTRYPOINT ["/bin/matterbridge", "-conf", "/conf/matterbridge.toml"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN apk update && apk add go git gcc musl-dev \
 FROM alpine:edge
 RUN apk --no-cache add ca-certificates mailcap
 COPY --from=builder /bin/matterbridge /bin/matterbridge
-RUN mkdir /conf
-RUN touch /conf/matterbridge.toml
-RUN ln -sf /matterbridge.toml /conf/matterbridge.toml
-ENTRYPOINT ["/bin/matterbridge", "-conf", "/conf/matterbridge.toml"]
+RUN mkdir /etc/matterbridge
+RUN touch /etc/matterbridge/matterbridge.toml
+RUN ln -sf /matterbridge.toml /etc/matterbridge/matterbridge.toml
+ENTRYPOINT ["/bin/matterbridge", "-conf", "/etc/matterbridge/matterbridge.toml"]


### PR DESCRIPTION
This change would be required for the Docker image to actually read `RELOADABLE` config options from the `matterbridge.toml`.

This edit would require https://github.com/42wim/matterbridge/wiki/Deploy:-Docker to be updated as well to mention that mounting would have to change to mounting a ***directory*** not a file. inotify inside Docker cannot read directly mounted files, only directories, for whatever reason.

-----
-----

Suggested wiki change:

## Docker

Create your matterbridge.toml file locally eg in `./conf/matterbridge.toml`.

```bash
docker run -ti -v ./conf:/conf
```

## Docker Compose

Create your matterbridge.toml file locally for example in `./conf/matterbridge.toml` and use this yaml as `docker-compose.yml`.

```yml
version: '3.7'
services:
  matterbridge:
    image: 42wim/matterbridge
    restart: unless-stopped
    volumes:
    - ./conf:/conf
```

Afterwards start the container with `docker-compose up -d`.

----

The above wiki changes could be altered as desired, but I wanted to illustrate what these Dockerfile changes would entail.