### PR TITLE
Ignore non-user messages (msteams). Fixes #1141

### DIFF
--- a/bridge/msteams/msteams.go
+++ b/bridge/msteams/msteams.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/42wim/matterbridge/bridge"
 	"github.com/42wim/matterbridge/bridge/config"
+	"github.com/davecgh/go-spew/spew"
 
 	"github.com/mattn/godown"
 	msgraph "github.com/yaegashi/msgraph.go/beta"
@@ -158,11 +159,22 @@ func (b *Bmsteams) poll(channelName string) error {
 					continue
 				}
 			}
+
+			if b.GetBool("debug") {
+				b.Log.Debug("Msg dump: ", spew.Sdump(msg))
+			}
+
+			// skip non-user message for now.
+			if msg.From.User == nil {
+				continue
+			}
+
 			if *msg.From.User.ID == b.botID {
 				b.Log.Debug("skipping own message")
 				msgmap[*msg.ID] = *msg.CreatedDateTime
 				continue
 			}
+
 			msgmap[*msg.ID] = *msg.CreatedDateTime
 			if msg.LastModifiedDateTime != nil {
 				msgmap[*msg.ID] = *msg.LastModifiedDateTime

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/Philipp15b/go-steam v1.0.1-0.20190816133340-b04c5a83c1c0
 	github.com/Rhymen/go-whatsapp v0.1.1-0.20200421062035-31e8111ac334
 	github.com/d5/tengo/v2 v2.4.2
+	github.com/davecgh/go-spew v1.1.1
 	github.com/fsnotify/fsnotify v1.4.9
 	github.com/go-telegram-bot-api/telegram-bot-api v4.6.5-0.20181225215658-ec221ba9ea45+incompatible
 	github.com/gomarkdown/markdown v0.0.0-20200127000047-1813ea067497


### PR DESCRIPTION
Ignore these messages for now, also add a extra
debug option for msteams so we can dump the whole
message.