### PR TITLE
Only colour IRC nicks if there is one.

### DIFF
--- a/bridge/irc/irc.go
+++ b/bridge/irc/irc.go
@@ -206,7 +206,7 @@ func (b *Birc) doSend() {
 	for msg := range b.Local {
 		<-throttle.C
 		username := msg.Username
-		if b.GetBool("Colornicks") {
+		if b.GetBool("Colornicks") && len(username) > 1 {
 			checksum := crc32.ChecksumIEEE([]byte(msg.Username))
 			colorCode := checksum%14 + 2 // quick fix - prevent white or black color codes
 			username = fmt.Sprintf("\x03%02d%s\x0F", colorCode, msg.Username)


### PR DESCRIPTION
Hello, very minor change, can we please implement this though?

I'm currently using tengo scripts for various modifications, but there is currently no way with tengo to set the first character in a message sent to IRC with the colour nick option turned on in config. matterbridge will always send an IRC colour/format code first.

My workaround is to send an empty nick string with this fix, which means I can make sure the first character from msgText is the first character in a message sent to IRC.