### PR TITLE
matrix: add support for global display names

### DIFF
--- a/matterbridge.toml.sample
+++ b/matterbridge.toml.sample
@@ -1213,6 +1213,10 @@ Password="yourpass"
 #OPTIONAL (default false)
 NoHomeServerSuffix=false
 
+#Whether to prefer display names when available. Currently this does not
+#support disambiguation if display names collide. (default false)
+#UseDisplayName=false
+
 #Whether to disable sending of HTML content to matrix
 #See https://github.com/42wim/matterbridge/issues/1022
 #OPTIONAL (default false)


### PR DESCRIPTION
Add support for using Matrix display names (/nick) in place of the account name.

Currently this is fairly bare-bones and doesn't support per-room nicks (/myroomnick in Riot) or disambiguation. Both of those appear to require tracking the display name for each channel/user pair, so it's probably best left for a later PR.