### PR TITLE
irc: skip gIRC built-in rate limiting

### DIFF
--- a/bridge/irc/irc.go
+++ b/bridge/irc/irc.go
@@ -250,6 +250,8 @@ func (b *Birc) getClient() (*girc.Client, error) {
 		SSL:        b.GetBool("UseTLS"),
 		TLSConfig:  &tls.Config{InsecureSkipVerify: b.GetBool("SkipTLSVerify"), ServerName: server}, //nolint:gosec
 		PingDelay:  time.Minute,
+		// skip gIRC internal rate limiting, since we have our own throttling
+		AllowFlood: true,
 	})
 	return i, nil
 }


### PR DESCRIPTION
By default, [gIRC rate limits all outgoing messages](https://github.com/lrstanley/girc/blob/master/conn.go#L435-L436). I found this behaviour particularly confusing when I tried to flood exempt the relay bot (since I own the network), so I've added a gIRC option settings to disable flood protection. Since matterbridge already implements message throttling, I don't believe this is extra layer of throttling is necessary.

(Alternatively, https://github.com/overdrivenetworks/matterbridge/commit/a351cc6f3ceb63f33bcacfc599a4084747c366b5 makes this a toggleable option)
