### PR TITLE
Add an option to log into a file rather than stdout

### DIFF
--- a/bridge/config/config.go
+++ b/bridge/config/config.go
@@ -250,7 +250,7 @@ func NewConfig(rootLogger *logrus.Logger, cfgfile string) Config {
 	cfgtype := detectConfigType(cfgfile)
 	mycfg := newConfigFromString(logger, input, cfgtype)
 	if mycfg.cv.General.LogFile != "" {
-		logfile, err := os.OpenFile(mycfg.cv.General.LogFile, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+		logfile, err := os.OpenFile(mycfg.cv.General.LogFile, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0600)
 		if err == nil {
 			logger.Info("Opening log file ", mycfg.cv.General.LogFile)
 			rootLogger.Out = logfile

--- a/bridge/config/config.go
+++ b/bridge/config/config.go
@@ -1,9 +1,9 @@
 package config
 
 import (
-	"os"
 	"bytes"
 	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -253,7 +253,7 @@ func NewConfig(rootLogger *logrus.Logger, cfgfile string) Config {
 		logfile, err := os.OpenFile(mycfg.cv.General.LogFile, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
 		if err == nil {
 			logger.Info("Opening log file ", mycfg.cv.General.LogFile)
-		        rootLogger.Out = logfile
+			rootLogger.Out = logfile
 		} else {
 			logger.Warn("Failed to open ", mycfg.cv.General.LogFile)
 		}

--- a/bridge/config/config.go
+++ b/bridge/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"os"
 	"bytes"
 	"io/ioutil"
 	"path/filepath"
@@ -93,6 +94,7 @@ type Protocol struct {
 	JoinDelay              string // all protocols
 	Label                  string // all protocols
 	Login                  string // mattermost, matrix
+	LogFile                string // general
 	MediaDownloadBlackList []string
 	MediaDownloadPath      string // Basically MediaServerUpload, but instead of uploading it, just write it to a file on the same server.
 	MediaDownloadSize      int    // all protocols
@@ -247,6 +249,15 @@ func NewConfig(rootLogger *logrus.Logger, cfgfile string) Config {
 
 	cfgtype := detectConfigType(cfgfile)
 	mycfg := newConfigFromString(logger, input, cfgtype)
+	if mycfg.cv.General.LogFile != "" {
+		logfile, err := os.OpenFile(mycfg.cv.General.LogFile, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+		if err == nil {
+			logger.Info("Opening log file ", mycfg.cv.General.LogFile)
+		        rootLogger.Out = logfile
+		} else {
+			logger.Warn("Failed to open ", mycfg.cv.General.LogFile)
+		}
+	}
 	if mycfg.cv.General.MediaDownloadSize == 0 {
 		mycfg.cv.General.MediaDownloadSize = 1000000
 	}

--- a/matterbridge.go
+++ b/matterbridge.go
@@ -54,9 +54,8 @@ func main() {
 	// if logging to a file, ensure it is closed when the program terminates
 	defer func() {
 		if f, ok := rootLogger.Out.(*os.File); ok {
-			if err := f.Sync(); err != nil {
-				f.Close()
-			}
+			f.Sync()
+			f.Close()
 		}
 	}()
 

--- a/matterbridge.go
+++ b/matterbridge.go
@@ -51,6 +51,14 @@ func main() {
 	cfg := config.NewConfig(rootLogger, *flagConfig)
 	cfg.BridgeValues().General.Debug = *flagDebug
 
+	// if logging to a file, ensure it is closed when the program terminates
+	defer func() {
+		if f, ok := rootLogger.Out.(*os.File); ok {
+			f.Sync()
+			f.Close()
+		}
+	}()
+
 	r, err := gateway.NewRouter(rootLogger, cfg, bridgemap.FullMap)
 	if err != nil {
 		logger.Fatalf("Starting gateway failed: %s", err)

--- a/matterbridge.go
+++ b/matterbridge.go
@@ -54,8 +54,9 @@ func main() {
 	// if logging to a file, ensure it is closed when the program terminates
 	defer func() {
 		if f, ok := rootLogger.Out.(*os.File); ok {
-			f.Sync()
-			f.Close()
+			if err := f.Sync(); err != nil {
+				f.Close()
+			}
 		}
 	}()
 

--- a/matterbridge.go
+++ b/matterbridge.go
@@ -52,6 +52,7 @@ func main() {
 	cfg.BridgeValues().General.Debug = *flagDebug
 
 	// if logging to a file, ensure it is closed when the program terminates
+	// nolint:errcheck
 	defer func() {
 		if f, ok := rootLogger.Out.(*os.File); ok {
 			f.Sync()

--- a/matterbridge.toml.sample
+++ b/matterbridge.toml.sample
@@ -1604,6 +1604,14 @@ MediaDownloadBlacklist=[".html$",".htm$"]
 #OPTIONAL (default false)
 IgnoreFailureOnStart=false
 
+#LogFile defines the location of a file to write logs into, rather
+#than stdout.
+#Logging will still happen on stdout if the file cannot be open for
+#writing, or if the value is empty. Note the the log won't roll, so
+#you might want to use logrotate(8) with this feature.
+#OPTIONAL (default empty)
+LogFile=/var/log/matterbridge.log
+
 ###################################################################
 #Tengo configuration
 ###################################################################

--- a/matterbridge.toml.sample
+++ b/matterbridge.toml.sample
@@ -1607,7 +1607,7 @@ IgnoreFailureOnStart=false
 #LogFile defines the location of a file to write logs into, rather
 #than stdout.
 #Logging will still happen on stdout if the file cannot be open for
-#writing, or if the value is empty. Note the the log won't roll, so
+#writing, or if the value is empty. Note that the log won't roll, so
 #you might want to use logrotate(8) with this feature.
 #OPTIONAL (default empty)
 LogFile=/var/log/matterbridge.log


### PR DESCRIPTION
This gives the ability to specify a filename to write the logs to, rather than `stdout`. It is useful for running it as a daemon when the service manager doesn't handle programs logging on stdout, like OpenBSD.

A better approach would probably be logging to syslog, so the system can handle file rotation, but I am not sure how to approach it. This is already useful as-is I think. Hope it helps !