### PR TITLE
fix MarkdownV2 support in Telegram

### DIFF
--- a/bridge/telegram/handlers.go
+++ b/bridge/telegram/handlers.go
@@ -322,9 +322,9 @@ func (b *Btelegram) handleEdit(msg *config.Message, chatid int64) (string, error
 	case "Markdown":
 		b.Log.Debug("Using mode markdown")
 		m.ParseMode = tgbotapi.ModeMarkdown
-	case "MarkdownV2":
+	case MarkdownV2:
 		b.Log.Debug("Using mode MarkdownV2")
-		m.ParseMode = "MarkdownV2"
+		m.ParseMode = MarkdownV2
 	}
 	if strings.ToLower(b.GetString("MessageFormat")) == HTMLNick {
 		b.Log.Debug("Using mode HTML - nick only")

--- a/bridge/telegram/handlers.go
+++ b/bridge/telegram/handlers.go
@@ -322,6 +322,9 @@ func (b *Btelegram) handleEdit(msg *config.Message, chatid int64) (string, error
 	case "Markdown":
 		b.Log.Debug("Using mode markdown")
 		m.ParseMode = tgbotapi.ModeMarkdown
+	case "MarkdownV2":
+		b.Log.Debug("Using mode MarkdownV2")
+		m.ParseMode = "MarkdownV2"
 	}
 	if strings.ToLower(b.GetString("MessageFormat")) == HTMLNick {
 		b.Log.Debug("Using mode HTML - nick only")

--- a/bridge/telegram/telegram.go
+++ b/bridge/telegram/telegram.go
@@ -15,6 +15,7 @@ const (
 	unknownUser = "unknown"
 	HTMLFormat  = "HTML"
 	HTMLNick    = "htmlnick"
+	MarkdownV2  = "MarkdownV2"
 )
 
 type Btelegram struct {
@@ -126,9 +127,9 @@ func (b *Btelegram) sendMessage(chatid int64, username, text string) (string, er
 		b.Log.Debug("Using mode markdown")
 		m.ParseMode = tgbotapi.ModeMarkdown
 	}
-	if b.GetString("MessageFormat") == "MarkdownV2" {
+	if b.GetString("MessageFormat") == MarkdownV2 {
 		b.Log.Debug("Using mode MarkdownV2")
-		m.ParseMode = "MarkdownV2"
+		m.ParseMode = MarkdownV2
 	}
 	if strings.ToLower(b.GetString("MessageFormat")) == HTMLNick {
 		b.Log.Debug("Using mode HTML - nick only")

--- a/bridge/telegram/telegram.go
+++ b/bridge/telegram/telegram.go
@@ -126,6 +126,10 @@ func (b *Btelegram) sendMessage(chatid int64, username, text string) (string, er
 		b.Log.Debug("Using mode markdown")
 		m.ParseMode = tgbotapi.ModeMarkdown
 	}
+	if b.GetString("MessageFormat") == "MarkdownV2" {
+		b.Log.Debug("Using mode MarkdownV2")
+		m.ParseMode = "MarkdownV2"
+	}
 	if strings.ToLower(b.GetString("MessageFormat")) == HTMLNick {
 		b.Log.Debug("Using mode HTML - nick only")
 		m.Text = username + html.EscapeString(text)

--- a/go.mod
+++ b/go.mod
@@ -47,7 +47,6 @@ require (
 	github.com/sirupsen/logrus v1.6.0
 	github.com/slack-go/slack v0.6.4
 	github.com/spf13/viper v1.7.0
-	github.com/stretchr/objx v0.1.1 // indirect
 	github.com/stretchr/testify v1.5.1
 	github.com/technoweenie/multipartstreamer v1.0.1 // indirect
 	github.com/writeas/go-strip-markdown v2.0.1+incompatible

--- a/go.mod
+++ b/go.mod
@@ -47,6 +47,7 @@ require (
 	github.com/sirupsen/logrus v1.6.0
 	github.com/slack-go/slack v0.6.4
 	github.com/spf13/viper v1.7.0
+	github.com/stretchr/objx v0.1.1 // indirect
 	github.com/stretchr/testify v1.5.1
 	github.com/technoweenie/multipartstreamer v1.0.1 // indirect
 	github.com/writeas/go-strip-markdown v2.0.1+incompatible


### PR DESCRIPTION
Without this, MarkdownM2 simply does not work.
Because only constant is taken from tgbotapi, here I just assigned the desired value.
Although in tgbotapi I also sent MR.