### PR TITLE
Support Telegram animated stickers (tgs) format

### DIFF
--- a/bridge/config/config.go
+++ b/bridge/config/config.go
@@ -100,6 +100,7 @@ type Protocol struct {
 	MediaDownloadSize      int    // all protocols
 	MediaServerDownload    string
 	MediaServerUpload      string
+	MediaConvertTgs        string     // telegram
 	MediaConvertWebPToPNG  bool       // telegram
 	MessageDelay           int        // IRC, time in millisecond to wait between messages
 	MessageFormat          string     // telegram

--- a/bridge/helper/helper.go
+++ b/bridge/helper/helper.go
@@ -5,7 +5,10 @@ import (
 	"fmt"
 	"image/png"
 	"io"
+	"io/ioutil"
 	"net/http"
+	"os"
+	"os/exec"
 	"regexp"
 	"strings"
 	"time"
@@ -192,7 +195,7 @@ func ParseMarkdown(input string) string {
 	return res
 }
 
-// ConvertWebPToPNG convert input data (which should be WebP format to PNG format)
+// ConvertWebPToPNG converts input data (which should be WebP format) to PNG format
 func ConvertWebPToPNG(data *[]byte) error {
 	r := bytes.NewReader(*data)
 	m, err := webp.Decode(r)
@@ -205,5 +208,51 @@ func ConvertWebPToPNG(data *[]byte) error {
 		return err
 	}
 	*data = w.Bytes()
+	return nil
+}
+
+// CanConvertTgsToX Checks whether the external command necessary for ConvertTgsToX works.
+func CanConvertTgsToX() error {
+	// We depend on the fact that `lottie_convert.py --help` has exit status 0.
+	// Hyrum's Law predicted this, and Murphy's Law predicts that this will break eventually.
+	// However, there is no alternative like `lottie_convert.py --is-properly-installed`
+	cmd := exec.Command("lottie_convert.py", "--help")
+	return cmd.Run()
+}
+
+// ConvertTgsToWebP convert input data (which should be tgs format) to WebP format
+// This relies on an external command, which is ugly, but works.
+func ConvertTgsToX(data *[]byte, outputFormat string, logger *logrus.Entry) error {
+	// lottie can't handle input from a pipe, so write to a temporary file:
+	tmpFile, err := ioutil.TempFile(os.TempDir(), "matterbridge-lottie-*.tgs")
+	if err != nil {
+		return err
+	}
+	tmpFileName := tmpFile.Name()
+	defer func() {
+		if removeErr := os.Remove(tmpFileName); removeErr != nil {
+			logger.Errorf("Could not delete temporary file %s: %v", tmpFileName, removeErr)
+		}
+	}()
+
+	if _, writeErr := tmpFile.Write(*data); writeErr != nil {
+		return writeErr
+	}
+	// Must close before calling lottie to avoid data races:
+	if closeErr := tmpFile.Close(); closeErr != nil {
+		return closeErr
+	}
+
+	// Call lottie to transform:
+	cmd := exec.Command("lottie_convert.py", "--input-format", "lottie", "--output-format", outputFormat, tmpFileName, "/dev/stdout")
+	cmd.Stderr = nil
+	// NB: lottie writes progress into to stderr in all cases.
+	stdout, stderr := cmd.Output()
+	if stderr != nil {
+		// 'stderr' already contains some parts of Stderr, because it was set to 'nil'.
+		return stderr
+	}
+
+	*data = stdout
 	return nil
 }

--- a/bridge/telegram/telegram.go
+++ b/bridge/telegram/telegram.go
@@ -2,6 +2,7 @@ package btelegram
 
 import (
 	"html"
+	"log"
 	"strconv"
 	"strings"
 
@@ -16,6 +17,8 @@ const (
 	HTMLFormat  = "HTML"
 	HTMLNick    = "htmlnick"
 	MarkdownV2  = "MarkdownV2"
+	FormatPng   = "png"
+	FormatWebp  = "webp"
 )
 
 type Btelegram struct {
@@ -25,6 +28,16 @@ type Btelegram struct {
 }
 
 func New(cfg *bridge.Config) bridge.Bridger {
+	tgsConvertFormat := cfg.GetString("MediaConvertTgs")
+	if tgsConvertFormat != "" {
+		err := helper.CanConvertTgsToX()
+		if err != nil {
+			log.Fatalf("Telegram bridge configured to convert .tgs files to '%s', but lottie does not appear to work:\n%#v", tgsConvertFormat, err)
+		}
+		if tgsConvertFormat != FormatPng && tgsConvertFormat != FormatWebp {
+			log.Fatalf("Telegram bridge configured to convert .tgs files to '%s', but only '%s' and '%s' are supported.", FormatPng, FormatWebp, tgsConvertFormat)
+		}
+	}
 	return &Btelegram{Config: cfg, avatarMap: make(map[string]string)}
 }
 


### PR DESCRIPTION
This is half a fix for #874

This patch introduces two new config flags:
- MediaConvertTgsToWebP
- MediaConvertTgsToPNG

These need to be treated independently from the existing MediaConvertWebPToPNG flag because Tgs→WebP results in an *animated* WebP, and the WebP→PNG converter can't handle animated WebP files yet.

Furthermore, some platforms (like discord) don't even support animated WebP files, so the user may want to fall back to static PNGs (not APNGs).

The final reason why this is only half a fix is that this introduces an external dependency, namely lottie, to be installed like this:

```
$ pip3 install lottie cairosvg
```

This patch works by writing the tgs to a temporary file in /tmp, calling lottie to convert it (this conversion may take several  econds!), and then deleting the temporary file.
The temporary file is absolutely necessary, as lottie refuses to work on non-seekable files.
If anyone comes up with a reasonable use case where /tmp is unavailable, I can add yet another config option for that, if desired.

Here's a screenshot of Discord, with `MediaConvertTgsToPNG=true`:

![Bildschirmfoto_2020-07-17_23-55-31](https://user-images.githubusercontent.com/2690845/87835141-93de0880-c88c-11ea-91b2-97b7d74753da.png)

As this requires new text in the Wiki, I'll post some suggestions below.