### PR TITLE
Add Dockerimage for tgs conversion

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+Dockerfile
+tgs.Dockerfile

--- a/tgs.Dockerfile
+++ b/tgs.Dockerfile
@@ -1,0 +1,38 @@
+FROM alpine:edge AS builder
+
+COPY . /go/src/github.com/42wim/matterbridge
+RUN apk add \
+    go \
+    git \
+    gcc \
+    musl-dev \
+  && cd /go/src/github.com/42wim/matterbridge \
+  && export GOPATH=/go \
+  && go get \
+  && go build -x -ldflags "-X main.githash=$(git log --pretty=format:'%h' -n 1)" -o /bin/matterbridge
+
+FROM alpine:edge
+RUN apk --no-cache add \
+    ca-certificates \
+    cairo \
+    libjpeg-turbo \
+    mailcap \
+    py3-webencodings \
+    python3 \
+  && apk --no-cache add --virtual .compile \
+    gcc \
+    libffi-dev \
+    libjpeg-turbo-dev \
+    musl-dev \
+    py3-pip \
+    py3-wheel \
+    python3-dev \
+    zlib-dev \
+  && pip3 install --no-cache-dir lottie[PNG] \
+  && apk --no-cache del .compile
+
+COPY --from=builder /bin/matterbridge /bin/matterbridge
+RUN mkdir /etc/matterbridge \
+  && touch /etc/matterbridge/matterbridge.toml \
+  && ln -sf /matterbridge.toml /etc/matterbridge/matterbridge.toml
+ENTRYPOINT ["/bin/matterbridge", "-conf", "/etc/matterbridge/matterbridge.toml"]


### PR DESCRIPTION
The tgs to png conversion support is quite large and adds almost 60MB to the final Docker Image and quite some build time. So I have decided to separate the Dockerfile to keep the normal one small and clean. 

It might be a good idea to add a separate tag on Docker HUB for this file.


```
matterbridge-tgs                            latest              d63dd203d4ad        29 minutes ago      136MB
42wim/matterbridge                          <none>              35630b8ef223        28 hours ago        72.8MB
``` 