### PR TITLE
Update nc-talk to version 0.1.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -49,7 +49,7 @@ require (
 	github.com/zfjagann/golang-ring v0.0.0-20190304061218-d34796e0a6c2
 	golang.org/x/image v0.0.0-20200618115811-c13761719519
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
-	gomod.garykim.dev/nc-talk v0.1.1
+	gomod.garykim.dev/nc-talk v0.1.2
 	gopkg.in/olahol/melody.v1 v1.0.0-20170518105555-d52139073376
 )
 

--- a/go.sum
+++ b/go.sum
@@ -420,8 +420,6 @@ github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJ
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
-github.com/monaco-io/request v1.0.3 h1:FsiIwXCCbHEyWx9A7lgg6JBTMHhHlEEsADsgAOvZ9HA=
-github.com/monaco-io/request v1.0.3/go.mod h1:EmggwHktBsbJmCgwZXqy7o0H1NNsAstQBWZrFVd3xtQ=
 github.com/monaco-io/request v1.0.4 h1:AbogA+IvPOWqyGZIFU7kSb8YS2Jv5Dnl5ncMj8cQV+o=
 github.com/monaco-io/request v1.0.4/go.mod h1:EmggwHktBsbJmCgwZXqy7o0H1NNsAstQBWZrFVd3xtQ=
 github.com/mreiferson/go-httpclient v0.0.0-20160630210159-31f0106b4474 h1:oKIteTqeSpenyTrOVj5zkiyCaflLa8B+CD0324otT+o=
@@ -856,12 +854,8 @@ golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-gomod.garykim.dev/nc-talk v0.0.2 h1:QagJzL1Ie/sJDachAC42fEXlIh2mK8IDk1/ue0u8IcI=
-gomod.garykim.dev/nc-talk v0.0.2/go.mod h1:0/Ksg0osAYmnWKs1OcCG+gBQ4HU1xiF1699g9B6jWZw=
-gomod.garykim.dev/nc-talk v0.1.0 h1:JCT36+bLuGpYFye+e8ZY8oj54K/1ij/lPvaH7yw38Rg=
-gomod.garykim.dev/nc-talk v0.1.0/go.mod h1:zKg8yxCk2KaTy6aPDEfRac0Jik72czX+nRsG8CZuhtc=
-gomod.garykim.dev/nc-talk v0.1.1 h1:hRQ5vjKS0AreTs5gDcAOWeoDcf2w6HAHvrj+6/L+lZ0=
-gomod.garykim.dev/nc-talk v0.1.1/go.mod h1:zKg8yxCk2KaTy6aPDEfRac0Jik72czX+nRsG8CZuhtc=
+gomod.garykim.dev/nc-talk v0.1.2 h1:bue+8NNlfdT8Z9rptcLa3Yud1t710egBw/lOC+ZUfj8=
+gomod.garykim.dev/nc-talk v0.1.2/go.mod h1:zKg8yxCk2KaTy6aPDEfRac0Jik72czX+nRsG8CZuhtc=
 google.golang.org/api v0.0.0-20180910000450-7ca32eb868bf/go.mod h1:4mhQ8q/RsB7i+udVvVy5NUi08OU8ZlA0gRVgrF7VFY0=
 google.golang.org/api v0.0.0-20181030000543-1d582fd0359e/go.mod h1:4mhQ8q/RsB7i+udVvVy5NUi08OU8ZlA0gRVgrF7VFY0=
 google.golang.org/api v0.0.0-20181220000619-583d854617af/go.mod h1:4mhQ8q/RsB7i+udVvVy5NUi08OU8ZlA0gRVgrF7VFY0=

--- a/vendor/gomod.garykim.dev/nc-talk/CHANGELOG.md
+++ b/vendor/gomod.garykim.dev/nc-talk/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.1.2](https://github.com/gary-kim/go-nc-talk/tree/v0.1.2) - 2020-08-28
+
+[Full Changelog](https://github.com/gary-kim/go-nc-talk/compare/v0.1.1...v0.1.2)
+
+### Fixed
+
+- Use lastReadMessage for first lastKnownMessageId [\#14](https://github.com/gary-kim/go-nc-talk/pull/14) ([@tilosp](https://github.com/tilosp))
+
 ## [v0.1.1](https://github.com/gary-kim/go-nc-talk/tree/v0.1.1) - 2020-08-24
 
 [Full Changelog](https://github.com/gary-kim/go-nc-talk/compare/v0.1.0...v0.1.1)

--- a/vendor/gomod.garykim.dev/nc-talk/room/room.go
+++ b/vendor/gomod.garykim.dev/nc-talk/room/room.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"io/ioutil"
+	"strconv"
 	"time"
 
 	"github.com/monaco-io/request"
@@ -98,16 +99,16 @@ func (t *TalkRoom) ReceiveMessages(ctx context.Context) (chan ocs.TalkRoomMessag
 		"includeLastKnown": "0",
 	}
 	lastKnown := ""
-	client := t.User.RequestClient(request.Client{
-		URL:     url,
-		Params:  requestParam,
-		Timeout: time.Second * 60,
-	})
-	res, err := client.Resp()
+	res, err := t.User.GetRooms()
 	if err != nil {
 		return nil, err
 	}
-	lastKnown = res.Header.Get("X-Chat-Last-Given")
+	for _, r := range *res {
+		if r.Token == t.Token {
+			lastKnown = strconv.Itoa(r.LastReadMessage)
+			break
+		}
+	}
 	go func() {
 		for {
 			if ctx.Err() != nil {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -291,7 +291,7 @@ golang.org/x/text/secure/bidirule
 golang.org/x/text/transform
 golang.org/x/text/unicode/bidi
 golang.org/x/text/unicode/norm
-# gomod.garykim.dev/nc-talk v0.1.1
+# gomod.garykim.dev/nc-talk v0.1.2
 gomod.garykim.dev/nc-talk
 gomod.garykim.dev/nc-talk/constants
 gomod.garykim.dev/nc-talk/ocs


### PR DESCRIPTION
This solves a problem where matterbridge spams a lot of old nctalk messages into bridged rooms on every restart.

See: https://github.com/gary-kim/go-nc-talk/pull/14

cc: @gary-kim