### PR TITLE
Add username formatting all events

### DIFF
--- a/bridge/matrix/matrix_test.go
+++ b/bridge/matrix/matrix_test.go
@@ -1,0 +1,28 @@
+package bmatrix
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPlainUsername(t *testing.T) {
+	uut := newMatrixUsername("MyUser")
+
+	assert.Equal(t, "MyUser", uut.formatted)
+	assert.Equal(t, "MyUser", uut.plain)
+}
+
+func TestHTMLUsername(t *testing.T) {
+	uut := newMatrixUsername("<b>MyUser</b>")
+
+	assert.Equal(t, "<b>MyUser</b>", uut.formatted)
+	assert.Equal(t, "MyUser", uut.plain)
+}
+
+func TestFancyUsername(t *testing.T) {
+	uut := newMatrixUsername("<MyUser>")
+
+	assert.Equal(t, "&lt;MyUser&gt;", uut.formatted)
+	assert.Equal(t, "<MyUser>", uut.plain)
+}


### PR DESCRIPTION
I added the formatted text to all event types.
Now the username should always be formatted when HTML formatting is used. Also formatting for media comments and notices is now supported.