### PR TITLE
nctalk: Add option to use User ID instead of Display Name as nick

### DIFF
--- a/bridge/nctalk/nctalk.go
+++ b/bridge/nctalk/nctalk.go
@@ -76,6 +76,7 @@ func (b *Btalk) JoinChannel(channel config.ChannelInfo) error {
 	if b.IsKeySet("GuestSuffix") {
 		guestSuffix = b.GetString("GuestSuffix")
 	}
+	userIdAsNick := b.GetBool("UserIdAsNick")
 
 	go func() {
 		for msg := range c {
@@ -88,7 +89,7 @@ func (b *Btalk) JoinChannel(channel config.ChannelInfo) error {
 			remoteMessage := config.Message{
 				Text:     formatRichObjectString(msg.Message, msg.MessageParameters),
 				Channel:  newRoom.room.Token,
-				Username: DisplayName(msg, guestSuffix),
+				Username: DisplayName(msg, guestSuffix, userIdAsNick),
 				UserID:   msg.ActorID,
 				Account:  b.Account,
 			}
@@ -152,7 +153,7 @@ func formatRichObjectString(message string, parameters map[string]ocs.RichObject
 	return message
 }
 
-func DisplayName(msg ocs.TalkRoomMessageData, suffix string) string {
+func DisplayName(msg ocs.TalkRoomMessageData, suffix string, userIdAsName bool) string {
 	if msg.ActorType == ocs.ActorGuest {
 		if msg.ActorDisplayName == "" {
 			return "Guest"
@@ -160,6 +161,9 @@ func DisplayName(msg ocs.TalkRoomMessageData, suffix string) string {
 
 		return msg.ActorDisplayName + suffix
 	}
-
+	// Use the user ID instead of the display name for non-guest users
+	if userIdAsName {
+		return msg.ActorID
+	}
 	return msg.ActorDisplayName
 }

--- a/matterbridge.toml.sample
+++ b/matterbridge.toml.sample
@@ -1407,6 +1407,9 @@ Password = "talkuserpass"
 
 # Suffix for Guest Users
 GuestSuffix = " (Guest)"
+# If true, use the User ID instead of Display Name for non-guest users
+# WARNING: Before using this, verify that your user IDs are indeed human-readable and intended for display.
+UserIdAsNick = false
 
 ###################################################################
 #


### PR DESCRIPTION
As proposed in [#1250](https://github.com/42wim/matterbridge/pull/1250#issuecomment-702180455).

Use case: The Nextcloud instance I intend to use this with gets its user accounts from an LDAP directory with nicknames as UIDs and full names as display names. However, in channels which are bridged to public IRC, I'd prefer to use nicknames rather than full names.

This change only applies to non-guest users, as they are already handled specially, and their UIDs are long hex strings (like 4247797f3cbf4fb2f4ee73995f2a2c683d32284e), which is quite unfit for display.