### PR TITLE
Skip empty messages.

### DIFF
--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -455,7 +455,7 @@ func (gw *Gateway) SendMessage(
 	}
 
 	// Skip empty messages.
-	if len(strings.TrimSpace(msg.Text)) < 1 {
+	if msg.Protocol != apiProtocol && len(strings.TrimSpace(msg.Text)) < 1 && len(strings.TrimSpace(msg.Username)) < 1 {
 		return "", nil
 	}
 

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -454,6 +454,11 @@ func (gw *Gateway) SendMessage(
 		gw.Router.MattermostPlugin <- msg
 	}
 
+	// Skip empty messages.
+	if len(strings.TrimSpace(msg.Text)) < 1 {
+		return "", nil
+	}
+
 	mID, err := dest.Send(msg)
 	if err != nil {
 		return mID, err


### PR DESCRIPTION
Currently empty messages are still attempted to send via every enabled bridge. This adds a lot of unnecessary overhead when using tengo scripts to skip certain messages by **blanking** msgText and msgUsername.

This little change cuts out empty messages earlier.

It intentionally doesn't check msgUsername, because I've seen a few tengo scripts blanking msgUsername in order to send chat commands over the bridge (to achieve getting the first character of the message be an ! or $ for example).

https://github.com/42wim/matterbridge/issues/942