### PR TITLE
Add the {SHORTPROTOCOL} string interpolation for RemoteNickFormat

### DIFF
--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -340,12 +340,13 @@ func (gw *Gateway) modifyUsername(msg *config.Message, dest *bridge.Bridge) stri
 		nick = strings.Replace(nick, "{NOPINGNICK}", msg.Username[:i]+"​"+msg.Username[i:], -1)
 	}
 
-	nick = strings.Replace(nick, "{BRIDGE}", br.Name, -1)
-	nick = strings.Replace(nick, "{PROTOCOL}", br.Protocol, -1)
-	nick = strings.Replace(nick, "{GATEWAY}", gw.Name, -1)
-	nick = strings.Replace(nick, "{LABEL}", br.GetString("Label"), -1)
-	nick = strings.Replace(nick, "{NICK}", msg.Username, -1)
-	nick = strings.Replace(nick, "{CHANNEL}", msg.Channel, -1)
+	nick = strings.ReplaceAll(nick, "{BRIDGE}", br.Name)
+	nick = strings.ReplaceAll(nick, "{PROTOCOL}", br.Protocol)
+	nick = strings.ReplaceAll(nick, "{SHORTPROTOCOL}", br.Protocol[:1])
+	nick = strings.ReplaceAll(nick, "{GATEWAY}", gw.Name)
+	nick = strings.ReplaceAll(nick, "{LABEL}", br.GetString("Label"))
+	nick = strings.ReplaceAll(nick, "{NICK}", msg.Username)
+	nick = strings.ReplaceAll(nick, "{CHANNEL}", msg.Channel)
 	tengoNick, err := gw.modifyUsernameTengo(msg, br)
 	if err != nil {
 		gw.logger.Errorf("modifyUsernameTengo error: %s", err)

--- a/matterbridge.toml.sample
+++ b/matterbridge.toml.sample
@@ -1629,6 +1629,9 @@ RemoteNickFormat="{NICK}"
 #The string "{BRIDGE}" (case sensitive) will be replaced by the sending bridge
 #The string "{LABEL}" (case sensitive) will be replaced by label= field of the sending bridge
 #The string "{PROTOCOL}" (case sensitive) will be replaced by the protocol used by the bridge
+#The string "{SHORTPROTOCOL}" (case sensitive) will be replaced by the first letter of the name
+#of the protocol used by the bridge. Beware that conflicts between protocols can happen (e.g. both
+#'slack' and 'steam' start with an 's')
 #The string "{GATEWAY}" (case sensitive) will be replaced by the origin gateway name that is replicating the message.
 #The string "{CHANNEL}" (case sensitive) will be replaced by the origin channel name used by the bridge
 #The string "{TENGO}" (case sensitive) will be replaced by the output of the RemoteNickFormat script under [tengo]


### PR DESCRIPTION
This new interpolation string for `RemoteNickFormat` allows for building shorter nicknames by only showing the first character in the name of the protocol.
As is noted in the `matterbridge.toml.sample` file, naming conflict can happen between different protocols, so users should take care of not having any conflicting protocols when using that option.