### PR TITLE
xmpp: add NoTLS option to allow plaintext XMPP connections

### DIFF
--- a/bridge/config/config.go
+++ b/bridge/config/config.go
@@ -117,7 +117,7 @@ type Protocol struct {
 	NicksPerRow            int        // mattermost, slack
 	NoHomeServerSuffix     bool       // matrix
 	NoSendJoinPart         bool       // all protocols
-	NoTLS                  bool       // mattermost
+	NoTLS                  bool       // mattermost, xmpp
 	Password               string     // IRC,mattermost,XMPP,matrix
 	PrefixMessagesWithNick bool       // mattemost, slack
 	PreserveThreading      bool       // slack

--- a/bridge/xmpp/xmpp.go
+++ b/bridge/xmpp/xmpp.go
@@ -138,14 +138,14 @@ func (b *Bxmpp) createXMPP() error {
 		User:                         b.GetString("Jid"),
 		Password:                     b.GetString("Password"),
 		NoTLS:                        true,
-		StartTLS:                     true,
+		StartTLS:                     !b.GetBool("NoTLS"),
 		TLSConfig:                    tc,
 		Debug:                        b.GetBool("debug"),
 		Session:                      true,
 		Status:                       "",
 		StatusMessage:                "",
 		Resource:                     "",
-		InsecureAllowUnencryptedAuth: false,
+		InsecureAllowUnencryptedAuth: b.GetBool("NoTLS"),
 	}
 	var err error
 	b.xc, err = options.NewClient()

--- a/matterbridge.toml.sample
+++ b/matterbridge.toml.sample
@@ -227,6 +227,10 @@ Nick="xmppbot"
 #OPTIONAL (default false)
 SkipTLSVerify=true
 
+#Enable to use plaintext connection to your XMPP server.
+#OPTIONAL (default false)
+NoTLS=true
+
 ## RELOADABLE SETTINGS
 ## Settings below can be reloaded by editing the file
 


### PR DESCRIPTION
The NoTLS option allows the bridge to work with XMPP servers that do not use TLS, like private intranet servers