### PR TITLE
Disable webhook editing (discord)

### DIFF
--- a/bridge/discord/discord.go
+++ b/bridge/discord/discord.go
@@ -142,12 +142,16 @@ func (b *Bdiscord) Connect() error {
 		}
 
 		b.canEditWebhooks = len(channelsDenied) == 0
-		if b.canEditWebhooks {
-			b.Log.Info("Can manage webhooks; will edit channel for global webhook on send")
-		} else {
-			b.Log.Warn("Can't manage webhooks; won't edit channel for global webhook on send")
-			b.Log.Warn("Can't manage webhooks in channels: ", strings.Join(channelsDenied, ", "))
-		}
+		b.canEditWebhooks = false
+		b.Log.Info("Webhook editing is disabled because of ratelimit issues")
+		/*
+			if b.canEditWebhooks {
+				b.Log.Info("Can manage webhooks; will edit channel for global webhook on send")
+			} else {
+				b.Log.Warn("Can't manage webhooks; won't edit channel for global webhook on send")
+				b.Log.Warn("Can't manage webhooks in channels: ", strings.Join(channelsDenied, ", "))
+			}
+		*/
 	}
 	b.channelsMutex.RUnlock()
 


### PR DESCRIPTION
See https://github.com/42wim/matterbridge/issues/1255 and
https://github.com/qaisjp/go-discord-irc/issues/57

Webhook edits gets ratelimited which cause other problems with
matterbridge. Disabling for now.