### PR TITLE
Add UserID to RemoteNickFormat and Tengo

### DIFF
--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -337,21 +337,21 @@ func (gw *Gateway) modifyUsername(msg *config.Message, dest *bridge.Bridge) stri
 			}
 			i++
 		}
-		nick = strings.Replace(nick, "{NOPINGNICK}", msg.Username[:i]+"​"+msg.Username[i:], -1)
+		nick = strings.ReplaceAll(nick, "{NOPINGNICK}", msg.Username[:i]+"​"+msg.Username[i:])
 	}
 
-	nick = strings.Replace(nick, "{BRIDGE}", br.Name, -1)
-	nick = strings.Replace(nick, "{PROTOCOL}", br.Protocol, -1)
-	nick = strings.Replace(nick, "{GATEWAY}", gw.Name, -1)
-	nick = strings.Replace(nick, "{LABEL}", br.GetString("Label"), -1)
-	nick = strings.Replace(nick, "{NICK}", msg.Username, -1)
-	nick = strings.Replace(nick, "{USERID}", msg.UserID, -1)
-	nick = strings.Replace(nick, "{CHANNEL}", msg.Channel, -1)
+	nick = strings.ReplaceAll(nick, "{BRIDGE}", br.Name)
+	nick = strings.ReplaceAll(nick, "{PROTOCOL}", br.Protocol)
+	nick = strings.ReplaceAll(nick, "{GATEWAY}", gw.Name)
+	nick = strings.ReplaceAll(nick, "{LABEL}", br.GetString("Label"))
+	nick = strings.ReplaceAll(nick, "{NICK}", msg.Username)
+	nick = strings.ReplaceAll(nick, "{USERID}", msg.UserID)
+	nick = strings.ReplaceAll(nick, "{CHANNEL}", msg.Channel)
 	tengoNick, err := gw.modifyUsernameTengo(msg, br)
 	if err != nil {
 		gw.logger.Errorf("modifyUsernameTengo error: %s", err)
 	}
-	nick = strings.Replace(nick, "{TENGO}", tengoNick, -1) //nolint:gocritic
+	nick = strings.ReplaceAll(nick, "{TENGO}", tengoNick)
 	return nick
 }
 

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -337,7 +337,7 @@ func (gw *Gateway) modifyUsername(msg *config.Message, dest *bridge.Bridge) stri
 			}
 			i++
 		}
-		nick = strings.ReplaceAll(nick, "{NOPINGNICK}", msg.Username[:i]+"​"+msg.Username[i:])
+		nick = strings.ReplaceAll(nick, "{NOPINGNICK}", msg.Username[:i]+"\u200b"+msg.Username[i:])
 	}
 
 	nick = strings.ReplaceAll(nick, "{BRIDGE}", br.Name)

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -345,6 +345,7 @@ func (gw *Gateway) modifyUsername(msg *config.Message, dest *bridge.Bridge) stri
 	nick = strings.Replace(nick, "{GATEWAY}", gw.Name, -1)
 	nick = strings.Replace(nick, "{LABEL}", br.GetString("Label"), -1)
 	nick = strings.Replace(nick, "{NICK}", msg.Username, -1)
+	nick = strings.Replace(nick, "{USERID}", msg.UserID, -1)
 	nick = strings.Replace(nick, "{CHANNEL}", msg.Channel, -1)
 	tengoNick, err := gw.modifyUsernameTengo(msg, br)
 	if err != nil {
@@ -544,6 +545,7 @@ func modifyInMessageTengo(filename string, msg *config.Message) error {
 	s.SetImports(stdlib.GetModuleMap(stdlib.AllModuleNames()...))
 	_ = s.Add("msgText", msg.Text)
 	_ = s.Add("msgUsername", msg.Username)
+	_ = s.Add("msgUserID", msg.UserID)
 	_ = s.Add("msgAccount", msg.Account)
 	_ = s.Add("msgChannel", msg.Channel)
 	c, err := s.Compile()
@@ -572,6 +574,7 @@ func (gw *Gateway) modifyUsernameTengo(msg *config.Message, br *bridge.Bridge) (
 	_ = s.Add("result", "")
 	_ = s.Add("msgText", msg.Text)
 	_ = s.Add("msgUsername", msg.Username)
+	_ = s.Add("msgUserID", msg.UserID)
 	_ = s.Add("nick", msg.Username)
 	_ = s.Add("msgAccount", msg.Account)
 	_ = s.Add("msgChannel", msg.Channel)
@@ -626,6 +629,7 @@ func (gw *Gateway) modifyOutMessageTengo(origmsg *config.Message, msg *config.Me
 	_ = s.Add("outEvent", msg.Event)
 	_ = s.Add("msgText", msg.Text)
 	_ = s.Add("msgUsername", msg.Username)
+	_ = s.Add("msgUserID", msg.UserID)
 	_ = s.Add("msgDrop", drop)
 	c, err := s.Compile()
 	if err != nil {

--- a/matterbridge.toml.sample
+++ b/matterbridge.toml.sample
@@ -1632,7 +1632,8 @@ RemoteNickFormat="{NICK}"
 ## Settings below can be reloaded by editing the file
 
 #RemoteNickFormat defines how remote users appear on this bridge
-#The string "{NICK}" (case sensitive) will be replaced by the actual nick / username.
+#The string "{NICK}" (case sensitive) will be replaced by the actual nick.
+#The string "{USERID}" (case sensitive) will be replaced by the user ID.
 #The string "{BRIDGE}" (case sensitive) will be replaced by the sending bridge
 #The string "{LABEL}" (case sensitive) will be replaced by label= field of the sending bridge
 #The string "{PROTOCOL}" (case sensitive) will be replaced by the protocol used by the bridge
@@ -1707,7 +1708,7 @@ LogFile="/var/log/matterbridge.log"
 #This script will receive every incoming message and can be used to modify the Username and the Text of that message.
 #The script will have the following global variables:
 #to modify: msgUsername and msgText
-#to read: msgChannel and msgAccount
+#to read: msgUserID, msgChannel, msgAccount
 #
 #The script is reloaded on every message, so you can modify the script on the fly.
 #
@@ -1731,6 +1732,7 @@ InMessage="example.tengo"
 #read-only:
 #inAccount, inProtocol, inChannel, inGateway, inEvent
 #outAccount, outProtocol, outChannel, outGateway, outEvent
+#msgUserID
 #
 #read-write:
 #msgText, msgUsername, msgDrop
@@ -1748,7 +1750,7 @@ OutMessage="example.tengo"
 #RemoteNickFormat allows you to specify the location of a tengo (https://github.com/d5/tengo/) script.
 #The script will have the following global variables:
 #to modify: result
-#to read: channel, bridge, gateway, protocol, nick
+#to read: channel, bridge, gateway, protocol, nick, msgUserID
 #
 #The result will be set in {TENGO} in the RemoteNickFormat key of every bridge where {TENGO} is specified
 #


### PR DESCRIPTION
Fixes #487.  I used `{USERID}` instead of `{USERNAME}` for less ambiguity because the term "Username" is already used in Tengo to refer to the nickname.