### PR TITLE
Add threading support with token (discord)

### DIFF
--- a/bridge/discord/handlers.go
+++ b/bridge/discord/handlers.go
@@ -127,6 +127,11 @@ func (b *Bdiscord) messageCreate(s *discordgo.Session, m *discordgo.MessageCreat
 	// Replace emotes
 	rmsg.Text = replaceEmotes(rmsg.Text)
 
+	// Add our parent id if it exists
+	if m.MessageReference != nil {
+		rmsg.ParentID = m.MessageReference.MessageID
+	}
+
 	b.Log.Debugf("<= Sending message from %s on %s to gateway", m.Author.Username, b.Account)
 	b.Log.Debugf("<= Message is %#v", rmsg)
 	b.Remote <- rmsg

--- a/bridge/mattermost/handlers.go
+++ b/bridge/mattermost/handlers.go
@@ -108,7 +108,7 @@ func (b *Bmattermost) handleMatterClient(messages chan *config.Message) {
 			Channel:  message.Channel,
 			Text:     message.Text,
 			ID:       message.Post.Id,
-			ParentID: message.Post.ParentId,
+			ParentID: message.Post.RootId, // ParentID is obsolete with mattermost
 			Extra:    make(map[string][]interface{}),
 		}
 

--- a/bridge/mattermost/mattermost.go
+++ b/bridge/mattermost/mattermost.go
@@ -127,6 +127,15 @@ func (b *Bmattermost) Send(msg config.Message) (string, error) {
 		msg.Text = fmt.Sprintf("[thread]: %s", msg.Text)
 	}
 
+	// we only can reply to the root of the thread, not to a specific ID (like discord for example does)
+	if msg.ParentID != "" {
+		post, res := b.mc.Client.GetPost(msg.ParentID, "")
+		if res.Error != nil {
+			b.Log.Errorf("getting post %s failed: %s", msg.ParentID, res.Error.DetailedError)
+		}
+		msg.ParentID = post.RootId
+	}
+
 	// Upload a file if it exists
 	if msg.Extra != nil {
 		for _, rmsg := range helper.HandleExtra(&msg, b.General) {

--- a/gateway/router.go
+++ b/gateway/router.go
@@ -160,7 +160,7 @@ func (r *Router) handleReceive() {
 				// For some bridges we always add/update the message ID.
 				// This is necessary as msgIDs will change if a bridge returns
 				// a different ID in response to edits.
-				if !exists || msg.Protocol == "discord" {
+				if !exists {
 					gw.Messages.Add(msg.Protocol+" "+msg.ID, msgIDs)
 				}
 			}


### PR DESCRIPTION
Webhooks don't support the threading yet, so this is token only. 
In discord you can reply on each message of a thread, but this is not possible in mattermost (so some changes added there to make sure we always answer on the rootID of the thread).

Also needs some more testing with slack.

**update** : It now also uses the token when replying to a thread (even if webhooks are enabled), until webhooks have support for threads.