### PR TITLE
Reject cross-channel message references (discord)

### DIFF
--- a/bridge/discord/handlers.go
+++ b/bridge/discord/handlers.go
@@ -127,9 +127,9 @@ func (b *Bdiscord) messageCreate(s *discordgo.Session, m *discordgo.MessageCreat
 	// Replace emotes
 	rmsg.Text = replaceEmotes(rmsg.Text)
 
-	// Add our parent id if it exists
-	if m.MessageReference != nil {
-		rmsg.ParentID = m.MessageReference.MessageID
+	// Add our parent id if it exists, and if it's not referring to a message in another channel
+	if ref := m.MessageReference; ref != nil && ref.ChannelID == m.ChannelID {
+		rmsg.ParentID = ref.MessageID
 	}
 
 	b.Log.Debugf("<= Sending message from %s on %s to gateway", m.Author.Username, b.Account)


### PR DESCRIPTION
Discord message references have been designed in a way for this to
support cross-channel or even cross-guild references in the future.

This will ensure the ParentID is *not* set when the message refers to a
message that was sent in a different channel.