### PR TITLE
Add jpe as valid image filename extension for telegram

### DIFF
--- a/bridge/telegram/handlers.go
+++ b/bridge/telegram/handlers.go
@@ -389,7 +389,7 @@ func (b *Btelegram) handleUploadFile(msg *config.Message, chatid int64) string {
 			Name:  fi.Name,
 			Bytes: *fi.Data,
 		}
-		re := regexp.MustCompile(".(jpg|png)$")
+		re := regexp.MustCompile(".(jpg|jpe|png)$")
 		if re.MatchString(fi.Name) {
 			c = tgbotapi.NewPhotoUpload(chatid, file)
 		} else {


### PR DESCRIPTION
When bridging from Whatsapp to Telegram images are sent as files by the telegram bot. That seems to be the case because they have a .jpe fileextension which is a valid jpeg fileextension. So the bridge should recognize them as images.