### PR TITLE
Allow the XMPP bridge to use slack compatible webhooks

### DIFF
--- a/bridge/xmpp/xmpp.go
+++ b/bridge/xmpp/xmpp.go
@@ -120,7 +120,7 @@ func (b *Bxmpp) Send(msg config.Message) (string, error) {
 			return "", err
 		}
 
-		return msg.ID, nil
+		return "", nil
 	}
 
 	// Post normal message.

--- a/matterbridge.toml.sample
+++ b/matterbridge.toml.sample
@@ -310,6 +310,11 @@ StripNick=false
 #OPTIONAL (default false)
 ShowTopicChange=false
 
+#Enable sending messages using a webhook instead of regular MUC messages.
+#Only works with a prosody server using mod_slack_webhook. Does not support editing.
+#OPTIONAL (default "")
+WebhookURL="https://yourdomain/prosody/msg/someid"
+
 ###################################################################
 #mattermost section
 ###################################################################


### PR DESCRIPTION
This PR tries to work on #1082 by giving the user the possibility to set a webhook for the XMPP bridge to allow user name spoofing.
This requires a prosody server with `mod_slack_webhooks` installed.

To add a webhook, just add the `WebhookURL` option to your XMPP section

```
[...]
[xmpp]
        [xmpp.test]
        [...]
        RemoteNickFormat="{NICK}"
        WebhookURL="https://some.server/msg/abc123"
[...]
```

This would POST a message to `https://some.server/msg/abc123/<channel>` when a message is received in the channel `<channel>`. Setting a webhook disables sending messages via the connected XMPP account on all channels that this account mirrors.

As mentioned in #1082 , using `mod_rest` may be the better solution, but it would currently require running prosody trunk or the yet unreleased version 0.12, so I settled on `mod_slack_webhook`.