### PR TITLE
Add even more debug option (discord)

### DIFF
--- a/bridge/discord/discord.go
+++ b/bridge/discord/discord.go
@@ -148,6 +148,11 @@ func (b *Bdiscord) Connect() error {
 		return fmt.Errorf("use of removed WebhookURL setting")
 	}
 
+	if b.GetInt("debuglevel") > 0 {
+		b.Log.Debug("enabling even more discord debug")
+		b.c.Debug = true
+	}
+
 	// Initialise webhook management
 	b.transmitter = transmitter.New(b.c, b.guildID, "matterbridge", b.useAutoWebhooks)
 	b.transmitter.Log = b.Log


### PR DESCRIPTION
Enable discordgo debugging with `debuglevel=1` under the `[discord.xxx]` section, for even more debugging fun.