### PR TITLE
Fix matterbridge crashing when using the XMPP webhook

### DIFF
--- a/bridge/xmpp/xmpp.go
+++ b/bridge/xmpp/xmpp.go
@@ -158,8 +158,13 @@ func (b *Bxmpp) postSlackCompatibleWebhook(msg config.Message) error {
 	}
 
 	resp, err := http.Post(b.GetString("WebhookURL")+"/"+msg.Channel, "application/json", bytes.NewReader(webhookBody))
+	if err != nil {
+		b.Log.Errorf("Failed to POST webhook: %s", err)
+		return err
+	}
+
 	resp.Body.Close()
-	return err
+	return nil
 }
 
 func (b *Bxmpp) createXMPP() error {


### PR DESCRIPTION
I recently deployed matterbridge with the XMPP webhook enabled on my server, but whenever someone wrote a message in a bridged channel that is not XMPP, the bridge would crash.

For me, it turned out that it was an invalid certificate. Nonetheless, matterbridge should tell you in the logs why it was not able to
POST the webhook.

This PR adds a log entry with the POST failure reason and prevents the bridge from "crashing" the bridge when a POST fails. 