### PR TITLE
Use valid transmitter Log default (discord)

### DIFF
--- a/bridge/discord/transmitter/transmitter.go
+++ b/bridge/discord/transmitter/transmitter.go
@@ -58,7 +58,7 @@ func New(session *discordgo.Session, guild string, title string, autoCreate bool
 
 		channelWebhooks: make(map[string]*discordgo.Webhook),
 
-		Log: log.NewEntry(nil),
+		Log: log.NewEntry(logrus.StandardLogger()),
 	}
 }
 

--- a/bridge/discord/transmitter/transmitter.go
+++ b/bridge/discord/transmitter/transmitter.go
@@ -58,7 +58,7 @@ func New(session *discordgo.Session, guild string, title string, autoCreate bool
 
 		channelWebhooks: make(map[string]*discordgo.Webhook),
 
-		Log: log.NewEntry(logrus.StandardLogger()),
+		Log: log.NewEntry(log.StandardLogger()),
 	}
 }
 


### PR DESCRIPTION
Using a logger created by `log.NewEntry(nil)` would crash. (matterbridge does not encounter this issue as it updates the Log field manually.)