### PR TITLE
Fix webhooks for channels with special characters

### DIFF
--- a/bridge/xmpp/xmpp.go
+++ b/bridge/xmpp/xmpp.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strings"
 	"sync"
 	"time"
@@ -157,7 +158,7 @@ func (b *Bxmpp) postSlackCompatibleWebhook(msg config.Message) error {
 		return err
 	}
 
-	resp, err := http.Post(b.GetString("WebhookURL")+"/"+msg.Channel, "application/json", bytes.NewReader(webhookBody))
+	resp, err := http.Post(b.GetString("WebhookURL")+"/"+url.QueryEscape(msg.Channel), "application/json", bytes.NewReader(webhookBody))
 	if err != nil {
 		b.Log.Errorf("Failed to POST webhook: %s", err)
 		return err


### PR DESCRIPTION
During my deployment of the XMPP webhook, I noticed that certain channels were not getting messages. Turns out, that that channel has a '#' in its URI, meaning that the webserver of prosody was interpreting it as an URL fragment and thus ignoring it.

This PR encodes the channel name to prevent such behaviour.