### PR TITLE
Change workflow from go 1.16.0-rc1 to go 1.16.x

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -16,7 +16,7 @@ jobs:
   test-build-upload:
     strategy:
       matrix:
-        go-version: [1.14.x, 1.15.x, 1.16.0-rc1]
+        go-version: [1.14.x, 1.15.x, 1.16.x]
         platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}
     steps:


### PR DESCRIPTION
https://golang.org/doc/devel/release.html#go1.16 released yesterday, and now checks are failing because the rc is no longer available https://github.com/42wim/matterbridge/runs/1920474638