### PR TITLE
Make function SendOOB in vendor/github.com/matterbridge/go-xmpp/xmpp.…

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ And more...
 ### 3rd party via matterbridge api
 
 - [Discourse](https://github.com/DeclanHoare/matterbabble)
+- [Facebook messenger](https://github.com/powerjungle/fbridge-asyncio)
 - [Facebook messenger](https://github.com/VictorNine/fbridge)
 - [Minecraft](https://github.com/elytra/MatterLink)
 - [Minecraft](https://github.com/raws/mattercraft)
@@ -129,6 +130,7 @@ Used by the projects below. Feel free to make a PR to add your project to this l
 - [Minecraft](https://github.com/raws/mattercraft) (Matterbridge link for Minecraft Server chat)
 - [pyCord](https://github.com/NikkyAI/pyCord) (crossplatform chatbot)
 - [Mattereddit](https://github.com/bonehurtingjuice/mattereddit) (Reddit chat support)
+- [fbridge-asyncio](https://github.com/powerjungle/fbridge-asyncio) (Facebook messenger support)
 - [fbridge](https://github.com/VictorNine/fbridge) (Facebook messenger support)
 - [matterbabble](https://github.com/DeclanHoare/matterbabble) (Discourse support)
 - [MatterAMXX](https://forums.alliedmods.net/showthread.php?t=319430) (Counter-Strike, half-life and more via AMXX mod)

--- a/bridge/telegram/handlers.go
+++ b/bridge/telegram/handlers.go
@@ -181,13 +181,15 @@ func (b *Btelegram) handleRecv(updates <-chan tgbotapi.Update) {
 // sends a EVENT_AVATAR_DOWNLOAD message to the gateway if successful.
 // logs an error message if it fails
 func (b *Btelegram) handleDownloadAvatar(userid int, channel string) {
-	rmsg := config.Message{Username: "system",
-		Text:    "avatar",
-		Channel: channel,
-		Account: b.Account,
-		UserID:  strconv.Itoa(userid),
-		Event:   config.EventAvatarDownload,
-		Extra:   make(map[string][]interface{})}
+	rmsg := config.Message{
+		Username: "system",
+		Text:     "avatar",
+		Channel:  channel,
+		Account:  b.Account,
+		UserID:   strconv.Itoa(userid),
+		Event:    config.EventAvatarDownload,
+		Extra:    make(map[string][]interface{}),
+	}
 
 	if _, ok := b.avatarMap[strconv.Itoa(userid)]; !ok {
 		photos, err := b.c.GetUserProfilePhotos(tgbotapi.UserProfilePhotosConfig{UserID: userid, Limit: 1})
@@ -413,7 +415,7 @@ func (b *Btelegram) handleQuote(message, quoteNick, quoteMessage string) string 
 	if format == "" {
 		format = "{MESSAGE} (re @{QUOTENICK}: {QUOTEMESSAGE})"
 	}
-	quoteMessagelength := len(quoteMessage)
+	quoteMessagelength := len([]rune(quoteMessage))
 	if b.GetInt("QuoteLengthLimit") != 0 && quoteMessagelength >= b.GetInt("QuoteLengthLimit") {
 		runes := []rune(quoteMessage)
 		quoteMessage = string(runes[0:b.GetInt("QuoteLengthLimit")])

--- a/bridge/xmpp/xmpp.go
+++ b/bridge/xmpp/xmpp.go
@@ -352,24 +352,12 @@ func (b *Bxmpp) handleUploadFile(msg *config.Message) error {
 	for _, file := range msg.Extra["file"] {
 		fileInfo := file.(config.FileInfo)
 		if fileInfo.Comment != "" {
-			msg.Text += fileInfo.Comment + ": "
+			msg.Text += fileInfo.Comment
 		}
 		if fileInfo.URL != "" {
-			msg.Text = fileInfo.URL
 			if fileInfo.Comment != "" {
-				msg.Text = fileInfo.Comment + ": " + fileInfo.URL
 				urlDesc = fileInfo.Comment
 			}
-		}
-		if _, err := b.xc.Send(xmpp.Chat{
-			Type:   "groupchat",
-			Remote: msg.Channel + "@" + b.GetString("Muc"),
-			Text:   msg.Username + msg.Text,
-		}); err != nil {
-			return err
-		}
-
-		if fileInfo.URL != "" {
 			if _, err := b.xc.SendOOB(xmpp.Chat{
 				Type:    "groupchat",
 				Remote:  msg.Channel + "@" + b.GetString("Muc"),
@@ -378,6 +366,13 @@ func (b *Bxmpp) handleUploadFile(msg *config.Message) error {
 			}); err != nil {
 				b.Log.WithError(err).Warn("Failed to send share URL.")
 			}
+		}
+		if _, err := b.xc.Send(xmpp.Chat{
+			Type:   "groupchat",
+			Remote: msg.Channel + "@" + b.GetString("Muc"),
+			Text:   msg.Username + msg.Text,
+		}); err != nil {
+			return err
 		}
 	}
 	return nil

--- a/vendor/github.com/matterbridge/go-xmpp/xmpp.go
+++ b/vendor/github.com/matterbridge/go-xmpp/xmpp.go
@@ -875,7 +875,7 @@ func (c *Client) Send(chat Chat) (n int, err error) {
 	return fmt.Fprintf(c.conn, stanza, xmlEscape(chat.Remote), xmlEscape(chat.Type), xmlEscape(chat.Text))
 }
 
-// SendOOB sends OOB data wrapped inside an XMPP message stanza, without actual body.
+// SendOOB sends OOB data wrapped inside an XMPP message stanza, with actual body to trigger inline display for modern XMPP clients
 func (c *Client) SendOOB(chat Chat) (n int, err error) {
 	var thdtext, oobtext string
 	if chat.Thread != `` {
@@ -888,8 +888,9 @@ func (c *Client) SendOOB(chat Chat) (n int, err error) {
 		}
 		oobtext += `</x>`
 	}
-	return fmt.Fprintf(c.conn, "<message to='%s' type='%s' id='%s' xml:lang='en'>"+oobtext+thdtext+"</message>",
-		xmlEscape(chat.Remote), xmlEscape(chat.Type), cnonce())
+	stanza := "<message to='%s' type='%s' id='%s' xml:lang='en'> <body>"+xmlEscape(chat.Ooburl)+"</body>" + oobtext + thdtext + "</message>"
+	
+	return fmt.Fprintf(c.conn, stanza, xmlEscape(chat.Remote), xmlEscape(chat.Type),cnonce())
 }
 
 // SendOrg sends the original text without being wrapped in an XMPP message stanza.


### PR DESCRIPTION
Resolve issue 42wim#1381.
Make function SendOOB in vendor/github.com/matterbridge/go-xmpp/xmpp.go to send meesage *with* actual body according to https://github.com/42wim/matterbridge/issues/1381#issuecomment-774032477

Remove the appendage `":" + fileInfo.URL` in bridge/xmpp/xmpp.go. This will not modify the message so that the link to the file is not sent in the text message. Instead the media file is available as inline display in modern XMPP clients.
Moreover, send the media attachement first, then the message.