### PR TITLE
discord: declare GUILD_MEMBERS privileged intent (fix nick tracking after connect)

### DIFF
--- a/bridge/discord/discord.go
+++ b/bridge/discord/discord.go
@@ -75,6 +75,11 @@ func (b *Bdiscord) Connect() error {
 	b.c.AddHandler(b.messageDeleteBulk)
 	b.c.AddHandler(b.memberAdd)
 	b.c.AddHandler(b.memberRemove)
+	// Add privileged intent for guild member tracking. This is needed to track nicks
+	// for display names and @mention translation
+	b.c.Identify.Intents = discordgo.MakeIntent(discordgo.IntentsAllWithoutPrivileged |
+		discordgo.IntentsGuildMembers)
+
 	err = b.c.Open()
 	if err != nil {
 		return err


### PR DESCRIPTION

Without this declared, it seems that Discord will not send any member update
events after connection, even if the privileged gateway intent is enabled for
the bot in settings. This causes nick tracking to get out of sync when people
change their nicks after the bot connects.

See: https://discord.com/developers/docs/topics/gateway#gateway-intents