### PR TITLE
add dependency libwebp-dev to tgs.Dockerfile

### DIFF
--- a/tgs.Dockerfile
+++ b/tgs.Dockerfile
@@ -12,6 +12,7 @@ RUN apk --no-cache add \
     ca-certificates \
     cairo \
     libjpeg-turbo \
+    libwebp-dev \
     mailcap \
     py3-webencodings \
     python3 \


### PR DESCRIPTION
The `tgs.Dockerfile` didn't install the dependency `libwebp-dev`. This made it impossible to render stickers to WebP.

Before:

```$ sudo docker exec sweet_chatelet lottie_convert.py --input-format lottie --output-format webp /etc/matterbridge/file_35_tgs.webp /etc/matterbridge/file_35_tgs.webp.webp
Traceback (most recent call last):
  File "/usr/bin/lottie_convert.py", line 158, in <module>
    exporter.process(an, outfile, **o_options)
  File "/usr/lib/python3.8/site-packages/lottie/parsers/baseporter.py", line 18, in process
    return self.callback(*a, **kw)
  File "/usr/lib/python3.8/site-packages/lottie/exporters/gif.py", line 77, in export_webp
    raise Exception("WebP animations not supported in this system")
Exception: WebP animations not supported in this system
```

After:

```
$ sudo docker exec serene_sammet lottie_convert.py --input-format lottie --output-format webp /etc/matterbridge/file_35_tgs.webp /etc/matterbridge/file_35_tgs.webp.webp
WebP frame rendering completed
WebP Writing to file...
```