### PR TITLE
matrix: content does not have body for redactions

### DIFF
--- a/bridge/matrix/matrix.go
+++ b/bridge/matrix/matrix.go
@@ -368,13 +368,6 @@ func (b *Bmatrix) handleEvent(ev *matrix.Event) {
 			Avatar:   b.getAvatarURL(ev.Sender),
 		}
 
-		// Text must be a string
-		if rmsg.Text, ok = ev.Content["body"].(string); !ok {
-			b.Log.Errorf("Content[body] is not a string: %T\n%#v",
-				ev.Content["body"], ev.Content)
-			return
-		}
-
 		// Remove homeserver suffix if configured
 		if b.GetBool("NoHomeServerSuffix") {
 			re := regexp.MustCompile("(.*?):.*")
@@ -387,6 +380,13 @@ func (b *Bmatrix) handleEvent(ev *matrix.Event) {
 			rmsg.ID = ev.Redacts
 			rmsg.Text = config.EventMsgDelete
 			b.Remote <- rmsg
+			return
+		}
+
+		// Text must be a string
+		if rmsg.Text, ok = ev.Content["body"].(string); !ok {
+			b.Log.Errorf("Content[body] is not a string: %T\n%#v",
+				ev.Content["body"], ev.Content)
 			return
 		}
 


### PR DESCRIPTION
While testing, I noticed that deletions from Matrix were running into an error. It seems to be because `m.room.redaction` does not have `content.body` according to the spec but the Matterbridge implementation expects it.

Redaction spec here: https://matrix.org/docs/spec/client_server/r0.6.1#m-room-redaction

This change makes it not required for redactions.