### PR TITLE
Fix XMPP parseNick function

### DIFF
--- a/bridge/xmpp/xmpp.go
+++ b/bridge/xmpp/xmpp.go
@@ -385,7 +385,7 @@ func (b *Bxmpp) handleUploadFile(msg *config.Message) error {
 
 func (b *Bxmpp) parseNick(remote string) string {
 	s := strings.Split(remote, "@")
-	if len(s) > 0 {
+	if len(s) > 1 {
 		s = strings.Split(s[1], "/")
 		if len(s) == 2 {
 			return s[1] // nick


### PR DESCRIPTION
The length of the split shall be higher than 1, if it equals 1 a crash will happen because of the following split which use the second value of the array created by the first split.