### PR TITLE
Add XMPP anonymous connection

### DIFF
--- a/bridge/xmpp/xmpp.go
+++ b/bridge/xmpp/xmpp.go
@@ -169,11 +169,21 @@ func (b *Bxmpp) postSlackCompatibleWebhook(msg config.Message) error {
 }
 
 func (b *Bxmpp) createXMPP() error {
-	if !strings.Contains(b.GetString("Jid"), "@") {
-		return fmt.Errorf("the Jid %s doesn't contain an @", b.GetString("Jid"))
+	var serverName string
+	switch {
+	case !b.GetBool("Anonymous"):
+		if !strings.Contains(b.GetString("Jid"), "@") {
+			return fmt.Errorf("the Jid %s doesn't contain an @", b.GetString("Jid"))
+		}
+		serverName = strings.Split(b.GetString("Jid"), "@")[1]
+	case !strings.Contains(b.GetString("Server"), ":"):
+		serverName = strings.Split(b.GetString("Server"), ":")[0]
+	default:
+		serverName = b.GetString("Server")
 	}
+
 	tc := &tls.Config{
-		ServerName:         strings.Split(b.GetString("Jid"), "@")[1],
+		ServerName:         serverName,
 		InsecureSkipVerify: b.GetBool("SkipTLSVerify"), // nolint: gosec
 	}
 

--- a/matterbridge.toml.sample
+++ b/matterbridge.toml.sample
@@ -223,12 +223,16 @@ UseRelayMsg=false
 #REQUIRED
 Server="jabber.example.com:5222"
 
+#Use anonymous MUC login
+#OPTIONAL (default false)
+Anonymous=false
+
 #Jid
-#REQUIRED
+#REQUIRED if Anonymous=false
 Jid="user@example.com"
 
 #Password
-#REQUIRED
+#REQUIRED if Anonymous=false
 Password="yourpass"
 
 #MUC


### PR DESCRIPTION
**Needs #1547 and matterbridge/go-xmpp#8**

Resolves #1354 

This PR try to add XMPP anonymous because go-xmpp already include it.
It will add a parameter "Anonymous" which make "Jid" and "Password" not needed if true

Example of config:
*I was making local testing with a prosody server*
``` TOML
[xmpp]
[xmpp.localhost]
debug=true
Anonymous=true
Server="anon.localhost"
Muc="room.localhost"
Nick="Matterbridge"
RemoteNickFormat="[{PROTOCOL}] <{NICK}> "
```

Note: Nickname works
![xmpp-peertube-matterbridge](https://user-images.githubusercontent.com/17492366/125517307-e01c127a-4272-43a7-94c7-d5d5bfbb4895.png)
