### PR TITLE
Add space before file upload comment (slack)

### DIFF
--- a/bridge/slack/slack.go
+++ b/bridge/slack/slack.go
@@ -459,7 +459,7 @@ func (b *Bslack) uploadFile(msg *config.Message, channelID string) {
 		b.cache.Add("filename"+fi.Name, ts)
 		initialComment := fmt.Sprintf("File from %s", msg.Username)
 		if fi.Comment != "" {
-			initialComment += fmt.Sprintf("with comment: %s", fi.Comment)
+			initialComment += fmt.Sprintf(" with comment: %s", fi.Comment)
 		}
 		res, err := b.sc.UploadFile(slack.FileUploadParameters{
 			Reader:          bytes.NewReader(*fi.Data),


### PR DESCRIPTION
Fixes a formatting bug when including a comment to a file upload (see screenshot below). Missing a space before `with`

![image](https://user-images.githubusercontent.com/8673088/126981300-7b8a8660-b236-4122-8299-0f6a38198d01.png)
