### PR TITLE
Not needed newline character in mumble bridge multiline messages

### DIFF
--- a/bridge/mumble/mumble.go
+++ b/bridge/mumble/mumble.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"net"
 	"strconv"
+	"strings"
 	"time"
 
 	"layeh.com/gumble/gumble"
@@ -252,8 +253,10 @@ func (b *Bmumble) processMessage(msg *config.Message) {
 	} else {
 		msgLines = helper.GetSubLines(msg.Text, 0, b.GetString("MessageClipped"))
 	}
-	// Send the individual lindes
+	// Send the individual lines
 	for i := range msgLines {
+		// Remove unnecessary newline character, since either way we're sending it as individual lines
+		msgLines[i] = strings.TrimSuffix(msgLines[i], "\n")
 		b.client.Self.Channel.Send(msg.Username+msgLines[i], false)
 	}
 }


### PR DESCRIPTION
Because it looks ugly and serves no purpose.

Before:
![Screenshot 2021-08-20 235634](https://user-images.githubusercontent.com/74188410/130297233-71737abc-ba5f-485a-8999-f9aaeaed4aa9.png)

After:
![Screenshot 2021-08-20 235705](https://user-images.githubusercontent.com/74188410/130297257-6606f5ed-d6fb-48d5-bdc1-1ae1a7329e03.png)

Message being sent:
![Screenshot 2021-08-20 235729](https://user-images.githubusercontent.com/74188410/130297291-c7597816-2af7-4c2c-ba76-c0b4d88b973b.png)
