### PR TITLE
Add UserName and RealName options for IRC

### DIFF
--- a/bridge/config/config.go
+++ b/bridge/config/config.go
@@ -138,6 +138,7 @@ type Protocol struct {
 	QuoteDisable           bool       // telegram
 	QuoteFormat            string     // telegram
 	QuoteLengthLimit       int        // telegram
+	RealName               string     // IRC
 	RejoinDelay            int        // IRC
 	ReplaceMessages        [][]string // all protocols
 	ReplaceNicks           [][]string // all protocols
@@ -169,6 +170,7 @@ type Protocol struct {
 	UseFirstName           bool       // telegram
 	UseUserName            bool       // discord, matrix
 	UseInsecureURL         bool       // telegram
+	UserName               string     // IRC
 	VerboseJoinPart        bool       // IRC
 	WebhookBindAddress     string     // mattermost, slack
 	WebhookURL             string     // mattermost, slack

--- a/bridge/irc/irc.go
+++ b/bridge/irc/irc.go
@@ -271,14 +271,21 @@ func (b *Birc) getClient() (*girc.Client, error) {
 	if err != nil {
 		return nil, err
 	}
+	user := b.GetString("UserName")
+	if user == "" {
+		user = b.GetString("Nick")
+	}
 	// fix strict user handling of girc
-	user := b.GetString("Nick")
 	for !girc.IsValidUser(user) {
 		if len(user) == 1 || len(user) == 0 {
 			user = "matterbridge"
 			break
 		}
 		user = user[1:]
+	}
+	realName := b.GetString("RealName")
+	if realName == "" {
+		realName = b.GetString("Nick")
 	}
 
 	debug := ioutil.Discard
@@ -299,7 +306,7 @@ func (b *Birc) getClient() (*girc.Client, error) {
 		Port:       port,
 		Nick:       b.GetString("Nick"),
 		User:       user,
-		Name:       b.GetString("Nick"),
+		Name:       realName,
 		SSL:        b.GetBool("UseTLS"),
 		TLSConfig:  &tls.Config{InsecureSkipVerify: b.GetBool("SkipTLSVerify"), ServerName: server}, //nolint:gosec
 		PingDelay:  pingDelay,

--- a/matterbridge.toml.sample
+++ b/matterbridge.toml.sample
@@ -55,6 +55,14 @@ Charset=""
 #REQUIRED
 Nick="matterbot"
 
+#Real name/gecos displayed in e.g. /WHOIS and /WHO
+#OPTIONAL (defaults to the nick)
+RealName="Matterbridge instance on IRC"
+
+#IRC username/ident preceding the hostname in hostmasks and /WHOIS
+#OPTIONAL (defaults to the nick)
+UserName="bridge"
+
 #If you registered your bot with a service like Nickserv on libera.
 #Also being used when UseSASL=true
 #


### PR DESCRIPTION
Currently matterbridge automatically uses its IRC nickname to fill in the username/ident and real name/gecos fields at server registration time. While there's no problem with this, sometimes it's very convenient to set a custom ident and real name that's more apropos to a bot/bridge's purpose, e.g. to allow the person who controls it to provide some short contact information in the bot's /WHOIS info, or some other kind of additional identification.

This just adds `UserName` and `RealName` config options for IRC to allow customizing those fields. They still default to the bridge's nickname if not specified.

(I will admit I'm unsure if those are the best possible names -- they may be a bit too IRC-centric.)