### PR TITLE
update arm dockerfile to build 1.22.3 fixes #1602

### DIFF
--- a/docker/arm/Dockerfile
+++ b/docker/arm/Dockerfile
@@ -1,9 +1,10 @@
 FROM alpine:edge as certs
 RUN apk --update add ca-certificates
+ARG VERSION=1.22.3
+ADD https://github.com/42wim/matterbridge/releases/download/v${VERSION}/matterbridge-${VERSION}-linux-arm64 /bin/matterbridge
+RUN chmod +x /bin/matterbridge
 
 FROM scratch
-ARG VERSION=1.12.3
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
-ADD https://github.com/42wim/matterbridge/releases/download/v${VERSION}/matterbridge-linux-arm /bin/matterbridge
-RUN chmod +x /bin/matterbridge
+COPY --from=certs /bin/matterbridge /bin/matterbridge
 ENTRYPOINT ["/bin/matterbridge"]


### PR DESCRIPTION
this should fix the build on arm, from scratch has no /bin/sh so it can't chmod matterbridge. this change moves the add and chmod to the earlier block with alpine.