### PR TITLE
Invalidate user in cache on user change event

### DIFF
--- a/bridge/slack/handlers.go
+++ b/bridge/slack/handlers.go
@@ -95,6 +95,8 @@ func (b *Bslack) handleSlackClient(messages chan *config.Message) {
 			b.users.populateUser(ev.User)
 		case *slack.HelloEvent, *slack.LatencyReport, *slack.ConnectingEvent:
 			continue
+		case *slack.UserChangeEvent:
+			b.users.invalidateUser(ev.User.ID)
 		default:
 			b.Log.Debugf("Unhandled incoming event: %T", ev)
 		}

--- a/bridge/slack/users_channels.go
+++ b/bridge/slack/users_channels.go
@@ -113,6 +113,12 @@ func (b *users) populateUser(userID string) {
 	b.users[userID] = user
 }
 
+func (b *users) invalidateUser(userID string) {
+	b.usersMutex.Lock()
+	defer b.usersMutex.Unlock()
+	delete(b.users, userID)
+}
+
 func (b *users) populateUsers(wait bool) {
 	b.refreshMutex.Lock()
 	if !wait && (time.Now().Before(b.earliestRefresh) || b.refreshInProgress) {


### PR DESCRIPTION
This is to fix #1600 - it invalidates a user in the cache upon receipt of a UserChangeEvent.