### PR TITLE
update GH actions to multi arch

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -20,6 +20,8 @@ jobs:
       -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v1
+        with:
+          platforms: amd64,arm64
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
@@ -45,12 +47,21 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - 
+        name: Log into registry ghcr.io
+        uses: docker/login-action@v1
+        if: github.event_name != 'pull_request'
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       -
         name: Build and push
         id: docker_build
         uses: docker/build-push-action@v2
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
add arm64 to the docker build
add the package to ghcr.io (github container registery)
this will make it so users can run matterbridge:latest and it will work on both amd64 & arm64

this will give you ghcr.io (github) as another registry along with dockerhub (it will show up under the package tab on this repo).

as of your latest changes to master branch ( cc6253a6b8de2e5fafa66f1d1be7ef0a1b2d352e) the branch compiles and runs on arm64/aarch64. so the /docker/arm/Dockerfile may not be needed anymore. These changes will add the arm build to mainline compile along with amd64.

So up to you if you wish to pick #1613 or this PR to merge :)