### PR TITLE
Fix #1529

### DIFF
--- a/bridge/xmpp/xmpp.go
+++ b/bridge/xmpp/xmpp.go
@@ -283,9 +283,9 @@ func (b *Bxmpp) handleXMPP() error {
 	for {
 		m, err := b.xc.Recv()
 		if err != nil {
+			// An error together with AvatarData is non-fatal
 			switch m.(type) {
 			case xmpp.AvatarData:
-				b.avatarAvailability[v.From] = false
 				continue
 			default:
 				return err

--- a/bridge/xmpp/xmpp.go
+++ b/bridge/xmpp/xmpp.go
@@ -283,7 +283,13 @@ func (b *Bxmpp) handleXMPP() error {
 	for {
 		m, err := b.xc.Recv()
 		if err != nil {
-			return err
+			switch m.(type) {
+			case xmpp.AvatarData:
+				b.avatarAvailability[v.From] = false
+				continue
+			default:
+				return err
+			}
 		}
 
 		switch v := m.(type) {


### PR DESCRIPTION
This PR attempts to fix #1529 by utilising https://github.com/mattn/go-xmpp/pull/133.

Short summary is that if we receive AvatarData and have a non-nil error, we just mark the avatar as not available and carry on.

Note that this PR is not yet tested and will require a bump of matterbridge/go-xmpp, once the go-xmpp PR has been tested/merged and brought to matterbridge's fork.