### PR TITLE
Allow binding to IP on IRC

### DIFF
--- a/bridge/irc/irc.go
+++ b/bridge/irc/irc.go
@@ -308,6 +308,7 @@ func (b *Birc) getClient() (*girc.Client, error) {
 		User:       user,
 		Name:       realName,
 		SSL:        b.GetBool("UseTLS"),
+		Bind:       b.GetString("Bind"),
 		TLSConfig:  &tls.Config{InsecureSkipVerify: b.GetBool("SkipTLSVerify"), ServerName: server}, //nolint:gosec
 		PingDelay:  pingDelay,
 		// skip gIRC internal rate limiting, since we have our own throttling

--- a/matterbridge.toml.sample
+++ b/matterbridge.toml.sample
@@ -34,6 +34,11 @@ UseSASL=false
 #OPTIONAL (default false)
 SkipTLSVerify=true
 
+#Local address to use for server connection
+#Note that Server and Bind must resolve to addresses of the same family.
+#OPTIONAL (default "")
+Bind=""
+
 #If you know your charset, you can specify it manually.
 #Otherwise it tries to detect this automatically. Select one below
 # "iso-8859-2:1987", "iso-8859-9:1989", "866", "latin9", "iso-8859-10:1992", "iso-ir-109", "hebrew",


### PR DESCRIPTION
Add configuration option "Bind" that is passed on to girc, allowing
to choose which IP address to use on systems that have multiple ones.