### PR TITLE
Adds support for code blocks in telegram

### DIFF
--- a/bridge/telegram/handlers.go
+++ b/bridge/telegram/handlers.go
@@ -453,11 +453,11 @@ func (b *Btelegram) handleEntities(rmsg *config.Message, message *tgbotapi.Messa
 		}
 
 		if e.Type == "code" {
-			rmsg.Text = "`" + rmsg.Text + "`" 			
+			rmsg.Text = rmsg.Text[0:e.Offset] + "`" + rmsg.Text[e.Offset:e.Offset + e.Length] + rmsg.Text[e.Offset + e.Length : len(rmsg.Text)] + "`"
 		}
 
 		if e.Type == "pre" {
-			rmsg.Text = "```\n" + rmsg.Text + "\n```" 
+			rmsg.Text = rmsg.Text[0:e.Offset] + "```\n" + rmsg.Text[e.Offset:e.Offset + e.Length] + rmsg.Text[e.Offset + e.Length : len(rmsg.Text)] + "\n```" 
 		}
 	}
 }

--- a/bridge/telegram/handlers.go
+++ b/bridge/telegram/handlers.go
@@ -435,6 +435,9 @@ func (b *Btelegram) handleEntities(rmsg *config.Message, message *tgbotapi.Messa
 	if message.Entities == nil {
 		return
 	}
+
+	var indexMovedBy = 0
+
 	// for now only do URL replacements
 	for _, e := range *message.Entities {
 		if e.Type == "text_link" {
@@ -453,11 +456,15 @@ func (b *Btelegram) handleEntities(rmsg *config.Message, message *tgbotapi.Messa
 		}
 
 		if e.Type == "code" {
-			rmsg.Text = rmsg.Text[0:e.Offset] + "`" + rmsg.Text[e.Offset:e.Offset + e.Length] + rmsg.Text[e.Offset + e.Length : len(rmsg.Text)] + "`"
+			var offset = e.Offset + indexMovedBy
+			rmsg.Text = rmsg.Text[:offset] + "`" + rmsg.Text[offset:offset + e.Length] + "`" + rmsg.Text[offset + e.Length :]
+			indexMovedBy += 2
 		}
 
 		if e.Type == "pre" {
-			rmsg.Text = rmsg.Text[0:e.Offset] + "```\n" + rmsg.Text[e.Offset:e.Offset + e.Length] + rmsg.Text[e.Offset + e.Length : len(rmsg.Text)] + "\n```" 
+			var offset = e.Offset + indexMovedBy			
+			rmsg.Text = rmsg.Text[:offset] + "```\n" + rmsg.Text[offset:offset + e.Length] + "\n```" + rmsg.Text[offset + e.Length :]			
+			indexMovedBy += 8
 		}
 	}
 }

--- a/bridge/telegram/handlers.go
+++ b/bridge/telegram/handlers.go
@@ -451,5 +451,9 @@ func (b *Btelegram) handleEntities(rmsg *config.Message, message *tgbotapi.Messa
 			link := utf16.Decode(utfEncodedString[e.Offset : e.Offset+e.Length])
 			rmsg.Text = strings.Replace(rmsg.Text, string(link), url.String(), 1)
 		}
+
+		if e.Type == "code" {
+			rmsg.Text = "`" + rmsg.Text + "`" 			
+		}
 	}
 }

--- a/bridge/telegram/handlers.go
+++ b/bridge/telegram/handlers.go
@@ -10,6 +10,7 @@ import (
 	"github.com/42wim/matterbridge/bridge/config"
 	"github.com/42wim/matterbridge/bridge/helper"
 	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api"
+	"fmt"
 )
 
 func (b *Btelegram) handleUpdate(rmsg *config.Message, message, posted, edited *tgbotapi.Message) *tgbotapi.Message {
@@ -454,6 +455,10 @@ func (b *Btelegram) handleEntities(rmsg *config.Message, message *tgbotapi.Messa
 
 		if e.Type == "code" {
 			rmsg.Text = "`" + rmsg.Text + "`" 			
+		}
+
+		if e.Type == "pre" {
+			rmsg.Text = "```\n" + rmsg.Text + "\n```" 
 		}
 	}
 }

--- a/bridge/telegram/handlers.go
+++ b/bridge/telegram/handlers.go
@@ -10,7 +10,6 @@ import (
 	"github.com/42wim/matterbridge/bridge/config"
 	"github.com/42wim/matterbridge/bridge/helper"
 	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api"
-	"fmt"
 )
 
 func (b *Btelegram) handleUpdate(rmsg *config.Message, message, posted, edited *tgbotapi.Message) *tgbotapi.Message {


### PR DESCRIPTION
if someone inputs a codeblock in telegram.

`code`
or
```
code
```

this will now be passed on, correctly.