### PR TITLE
Added: Dependabot.yml config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,18 +5,18 @@ version: 2
 updates:
   - package-ecosystem: gomod
     directory: /
-    schedule: {interval: monthly}
+    schedule: {interval: daily}
     reviewers: [42wim]
     assignees: [42wim]
 
   - package-ecosystem: github-actions
     directory: /
-    schedule: {interval: monthly}
+    schedule: {interval: daily}
     reviewers: [42wim]
     assignees: [42wim]
 
   - package-ecosystem: docker
     directory: /
-    schedule: {interval: monthly}
+    schedule: {interval: daily}
     reviewers: [42wim]
     assignees: [42wim]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,18 +5,18 @@ version: 2
 updates:
   - package-ecosystem: gomod
     directory: /
-    schedule: {interval: daily}
+    schedule: {interval: weekly}
     reviewers: [42wim]
     assignees: [42wim]
 
   - package-ecosystem: github-actions
     directory: /
-    schedule: {interval: daily}
+    schedule: {interval: weekly}
     reviewers: [42wim]
     assignees: [42wim]
 
   - package-ecosystem: docker
     directory: /
-    schedule: {interval: daily}
+    schedule: {interval: weekly}
     reviewers: [42wim]
     assignees: [42wim]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+# Docs: <https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/customizing-dependency-updates>
+
+version: 2
+
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule: {interval: monthly}
+    reviewers: [42wim]
+    assignees: [42wim]
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule: {interval: monthly}
+    reviewers: [42wim]
+    assignees: [42wim]
+
+  - package-ecosystem: docker
+    directory: /
+    schedule: {interval: monthly}
+    reviewers: [42wim]
+    assignees: [42wim]


### PR DESCRIPTION
## What does this PR do?
This PR adds dependabot. Dependabot will take care of package updates (e.g. go.mod dependency updates, Dockerfile image tag updates and the gh actions used).

## Why is it needed?
I think it's quite useful because @42wim doesn't really need to keep an eye on go/docker/gh-actions updates anymore, since Dependabot will create monthly PRs about the new updates of the used components. This will improve the security of the project as dependencies with security holes can be patched quickly.


I would really appreciate feedback on this PR :smile: