### PR TITLE
Reply support for Matrix

### DIFF
--- a/bridge/matrix/matrix.go
+++ b/bridge/matrix/matrix.go
@@ -289,16 +289,16 @@ func (b *Bmatrix) Send(msg config.Message) (string, error) {
 	}
 
 	if msg.ParentValid() {
-		m := ReplyMessage {
-			TextMessage: matrix.TextMessage {
+		m := ReplyMessage{
+			TextMessage: matrix.TextMessage{
 				MsgType:       "m.text",
 				Body:          username.plain + msg.Text,
 				FormattedBody: username.formatted + helper.ParseMarkdown(msg.Text),
 			},
 		}
 
-		m.RelatedTo = InReplyToRelation {
-			InReplyTo: InReplyToRelationContent {
+		m.RelatedTo = InReplyToRelation{
+			InReplyTo: InReplyToRelationContent{
 				EventID: msg.ParentID,
 			},
 		}

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -454,9 +454,9 @@ func (gw *Gateway) SendMessage(
 		msg.Channel = rmsg.Channel
 	}
 
-	msg.ParentID = gw.getDestMsgID(rmsg.Protocol+" "+canonicalParentMsgID, dest, channel)
+	msg.ParentID = gw.getDestMsgID(canonicalParentMsgID, dest, channel)
 	if msg.ParentID == "" {
-		msg.ParentID = canonicalParentMsgID
+		msg.ParentID = strings.Replace(canonicalParentMsgID, dest.Protocol+" ", "", 1)
 	}
 
 	// if the parentID is still empty and we have a parentID set in the original message

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -66,7 +66,7 @@ func New(rootLogger *logrus.Logger, cfg *config.Gateway, r *Router) *Gateway {
 func (gw *Gateway) FindCanonicalMsgID(protocol string, mID string) string {
 	ID := protocol + " " + mID
 	if gw.Messages.Contains(ID) {
-		return mID
+		return ID
 	}
 
 	// If not keyed, iterate through cache for downstream, and infer upstream.
@@ -75,7 +75,7 @@ func (gw *Gateway) FindCanonicalMsgID(protocol string, mID string) string {
 		ids := v.([]*BrMsgID)
 		for _, downstreamMsgObj := range ids {
 			if ID == downstreamMsgObj.ID {
-				return strings.Replace(mid.(string), protocol+" ", "", 1)
+				return mid.(string)
 			}
 		}
 	}


### PR DESCRIPTION
Implements sending and receiving reply messages for Matrix bridges

In doing this, I moved the protocol stripping downstream from FindCanonicalMsgID since the previous behaviour made the ParentID value inconsistent