### PR TITLE
Make EditSuffix option actually work (whatsapp). Fixes #1510

### DIFF
--- a/bridge/whatsapp/whatsapp.go
+++ b/bridge/whatsapp/whatsapp.go
@@ -293,7 +293,11 @@ func (b *Bwhatsapp) Send(msg config.Message) (string, error) {
 	if msg.ID != "" {
 		b.Log.Debugf("updating message with id %s", msg.ID)
 
-		msg.Text += " (edited)"
+		if b.GetString("editsuffix") != "" {
+			msg.Text += b.GetString("EditSuffix")
+		} else {
+			msg.Text += " (edited)"
+		}
 	}
 
 	// Handle Upload a file


### PR DESCRIPTION
To keep it backwards compatible we keep the "(edited)" message when no
editsuffix is configured.