### PR TITLE
Fix Telegram channel title in forwards

### DIFF
--- a/bridge/telegram/handlers.go
+++ b/bridge/telegram/handlers.go
@@ -57,6 +57,11 @@ func (b *Btelegram) handleForwarded(rmsg *config.Message, message *tgbotapi.Mess
 		return
 	}
 
+	if message.ForwardFromChat != nil && message.ForwardFrom == nil {
+		rmsg.Text = "Forwarded from " + message.ForwardFromChat.Title + ": " + rmsg.Text
+		return
+	}
+
 	if message.ForwardFrom == nil {
 		rmsg.Text = "Forwarded from " + unknownUser + ": " + rmsg.Text
 		return


### PR DESCRIPTION
Forward from channels requires different handling than forward from the regular users.
This patch fixes the issue: it prints channel title instead of "forwarded from unknown".