### PR TITLE
Preserve threading from telegram replies

### DIFF
--- a/bridge/telegram/handlers.go
+++ b/bridge/telegram/handlers.go
@@ -187,6 +187,11 @@ func (b *Btelegram) handleRecv(updates <-chan tgbotapi.Update) {
 		rmsg.ID = strconv.Itoa(message.MessageID)
 		rmsg.Channel = strconv.FormatInt(message.Chat.ID, 10)
 
+		// preserve threading from telegram reply
+		if message.ReplyToMessage != nil {
+			rmsg.ParentID = strconv.Itoa(message.ReplyToMessage.MessageID)
+		}
+
 		// handle entities (adding URLs)
 		b.handleEntities(&rmsg, message)
 

--- a/bridge/telegram/telegram.go
+++ b/bridge/telegram/telegram.go
@@ -152,11 +152,11 @@ func (b *Btelegram) getFileDirectURL(id string) string {
 	return res
 }
 
-func (b *Btelegram) sendMessage(chatid int64, username, text, parentId string) (string, error) {
+func (b *Btelegram) sendMessage(chatid int64, username, text, parentID string) (string, error) {
 	m := tgbotapi.NewMessage(chatid, "")
 	m.Text, m.ParseMode = TGGetParseMode(b, username, text)
-	if parentId != "" {
-		rmid, err := strconv.Atoi(parentId)
+	if parentID != "" {
+		rmid, err := strconv.Atoi(parentID)
 		if err != nil {
 			return "", err
 		}

--- a/bridge/telegram/telegram.go
+++ b/bridge/telegram/telegram.go
@@ -1,6 +1,7 @@
 package btelegram
 
 import (
+	"fmt"
 	"html"
 	"log"
 	"strconv"
@@ -106,6 +107,12 @@ func (b *Btelegram) Send(msg config.Message) (string, error) {
 	// Delete message
 	if msg.Event == config.EventMsgDelete {
 		return b.handleDelete(&msg, chatid)
+	}
+
+	// Handle prefix hint for unthreaded messages.
+	if msg.ParentNotFound() {
+		msg.ParentID = ""
+		msg.Text = fmt.Sprintf("[reply]: %s", msg.Text)
 	}
 
 	// Upload a file if it exists

--- a/matterbridge.toml.sample
+++ b/matterbridge.toml.sample
@@ -1141,6 +1141,12 @@ StripNick=false
 #OPTIONAL (default false)
 ShowTopicChange=false
 
+#Opportunistically preserve threaded replies between Telegram groups.
+#This only works if the parent message is still in the cache.
+#Cache is flushed between restarts.
+#OPTIONAL (default false)
+PreserveThreading=false
+
 ###################################################################
 #rocketchat section
 ###################################################################


### PR DESCRIPTION
I've tested it between Slack and Telegram - all fine.

Telegram replies appears as thread replies in Slack, and Slack thread replies appears as Telegram replies in Telegram.