### PR TITLE
Telegram: Multiple media in one message

### DIFF
--- a/bridge/telegram/handlers.go
+++ b/bridge/telegram/handlers.go
@@ -491,7 +491,7 @@ func (b *Btelegram) handleUploadFile(msg *config.Message, chatid int64) (string,
 			}
 			res, err := b.c.Send(voc)
 			if err != nil {
-				b.Log.Errorf("file upload failed: %#v", err)
+				return "", err
 			}
 			resId = strconv.Itoa(res.MessageID)
 		default:
@@ -510,7 +510,7 @@ func (b *Btelegram) handleUploadFile(msg *config.Message, chatid int64) (string,
 		}
 		messages, err := b.c.SendMediaGroup(mg)
 		if err != nil {
-			b.Log.Errorf("file upload failed: %#v", err)
+			return "", err
 		}
 		// get first message id
 		resId = strconv.Itoa(messages[0].MessageID)

--- a/bridge/telegram/handlers.go
+++ b/bridge/telegram/handlers.go
@@ -490,11 +490,7 @@ func (b *Btelegram) handleUploadFile(msg *config.Message, chatid int64, parentID
 		}
 	}
 
-	if len(media) > 0 {
-		return b.sendMediaFiles(msg, chatid, parentID, media)
-	}
-
-	return "", nil
+	return b.sendMediaFiles(msg, chatid, parentID, media)
 }
 
 func (b *Btelegram) handleQuote(message, quoteNick, quoteMessage string) string {

--- a/bridge/telegram/handlers.go
+++ b/bridge/telegram/handlers.go
@@ -111,7 +111,11 @@ func (b *Btelegram) handleQuoting(rmsg *config.Message, message *tgbotapi.Messag
 			usernameReply = unknownUser
 		}
 		if !b.GetBool("QuoteDisable") {
-			rmsg.Text = b.handleQuote(rmsg.Text, usernameReply, message.ReplyToMessage.Text)
+			quote := message.ReplyToMessage.Text
+			if quote == "" {
+				quote = message.ReplyToMessage.Caption
+			}
+			rmsg.Text = b.handleQuote(rmsg.Text, usernameReply, quote)
 		}
 	}
 }

--- a/bridge/telegram/handlers.go
+++ b/bridge/telegram/handlers.go
@@ -473,9 +473,7 @@ func (b *Btelegram) handleUploadFile(msg *config.Message, chatid int64, parentID
 		case ".ogg":
 			voc := tgbotapi.NewVoice(chatid, file)
 			voc.Caption, voc.ParseMode = TGGetParseMode(b, msg.Username, fi.Comment)
-			if parentID != 0 {
-				voc.ReplyToMessageID = parentID
-			}
+			voc.ReplyToMessageID = parentID
 			res, err := b.c.Send(voc)
 			if err != nil {
 				return "", err

--- a/bridge/telegram/telegram.go
+++ b/bridge/telegram/telegram.go
@@ -124,7 +124,7 @@ func (b *Btelegram) Send(msg config.Message) (string, error) {
 		}
 		// check if we have files to upload (from slack, telegram or mattermost)
 		if len(msg.Extra["file"]) > 0 {
-			b.handleUploadFile(&msg, chatid)
+			return b.handleUploadFile(&msg, chatid)
 		}
 	}
 

--- a/bridge/telegram/telegram.go
+++ b/bridge/telegram/telegram.go
@@ -172,6 +172,9 @@ func (b *Btelegram) sendMessage(chatid int64, username, text string, parentID in
 
 // sendMediaFiles native upload media files via media group
 func (b *Btelegram) sendMediaFiles(msg *config.Message, chatid int64, parentID int, media []interface{}) (string, error) {
+	if len(media) == 0 {
+		return "", nil
+	}
 	mg := tgbotapi.MediaGroupConfig{ChatID: chatid, ChannelUsername: msg.Username, Media: media, ReplyToMessageID: parentID}
 	messages, err := b.c.SendMediaGroup(mg)
 	if err != nil {

--- a/bridge/telegram/telegram.go
+++ b/bridge/telegram/telegram.go
@@ -115,16 +115,21 @@ func (b *Btelegram) Send(msg config.Message) (string, error) {
 		msg.Text = fmt.Sprintf("[reply]: %s", msg.Text)
 	}
 
+	var parentID int
+	if msg.ParentID != "" {
+		parentID, _ = b.intParentID(msg.ParentID)
+	}
+
 	// Upload a file if it exists
 	if msg.Extra != nil {
 		for _, rmsg := range helper.HandleExtra(&msg, b.General) {
-			if _, msgErr := b.sendMessage(chatid, rmsg.Username, rmsg.Text, msg.ParentID); msgErr != nil {
+			if _, msgErr := b.sendMessage(chatid, rmsg.Username, rmsg.Text, parentID); msgErr != nil {
 				b.Log.Errorf("sendMessage failed: %s", msgErr)
 			}
 		}
 		// check if we have files to upload (from slack, telegram or mattermost)
 		if len(msg.Extra["file"]) > 0 {
-			return b.handleUploadFile(&msg, chatid)
+			return b.handleUploadFile(&msg, chatid, parentID)
 		}
 	}
 
@@ -138,7 +143,7 @@ func (b *Btelegram) Send(msg config.Message) (string, error) {
 	// Ignore empty text field needs for prevent double messages from whatsapp to telegram
 	// when sending media with text caption
 	if msg.Text != "" {
-		return b.sendMessage(chatid, msg.Username, msg.Text, msg.ParentID)
+		return b.sendMessage(chatid, msg.Username, msg.Text, parentID)
 	}
 
 	return "", nil
@@ -152,16 +157,10 @@ func (b *Btelegram) getFileDirectURL(id string) string {
 	return res
 }
 
-func (b *Btelegram) sendMessage(chatid int64, username, text, parentID string) (string, error) {
+func (b *Btelegram) sendMessage(chatid int64, username, text string, parentID int) (string, error) {
 	m := tgbotapi.NewMessage(chatid, "")
 	m.Text, m.ParseMode = TGGetParseMode(b, username, text)
-	if parentID != "" {
-		rmid, err := strconv.Atoi(parentID)
-		if err != nil {
-			return "", err
-		}
-		m.ReplyToMessageID = rmid
-	}
+	m.ReplyToMessageID = parentID
 	m.DisableWebPagePreview = b.GetBool("DisableWebPagePreview")
 
 	res, err := b.c.Send(m)
@@ -169,6 +168,26 @@ func (b *Btelegram) sendMessage(chatid int64, username, text, parentID string) (
 		return "", err
 	}
 	return strconv.Itoa(res.MessageID), nil
+}
+
+// sendMediaFiles native upload media files via media group
+func (b *Btelegram) sendMediaFiles(msg *config.Message, chatid int64, parentID int, media []interface{}) (string, error) {
+	mg := tgbotapi.MediaGroupConfig{ChatID: chatid, ChannelUsername: msg.Username, Media: media, ReplyToMessageID: parentID}
+	messages, err := b.c.SendMediaGroup(mg)
+	if err != nil {
+		return "", err
+	}
+	// return first message id
+	return strconv.Itoa(messages[0].MessageID), nil
+}
+
+// intParentID return integer parent id for telegram message
+func (b *Btelegram) intParentID(parentID string) (int, error) {
+	pid, err := strconv.Atoi(parentID)
+	if err != nil {
+		return 0, err
+	}
+	return pid, nil
 }
 
 func (b *Btelegram) cacheAvatar(msg *config.Message) (string, error) {


### PR DESCRIPTION
In this PR:

1. Fix for quoting when message have media with caption.
2. Send message with multiple media as one message with media group.
3. Preserve threading for telegram messages with files.

I've test this changes via Slack and Telegram.

Old behavior: Sending one message with 3 images/files from Slack produces 3 telegram messages with one image/file each.
New behavior: Sending one message with 3 images/files from Slack produces one telegram message with 3 images/files.