### PR TITLE
Ignore sending file with comment, if comment contains IgnoreMessages value

### DIFF
--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -312,7 +312,10 @@ func (gw *Gateway) ignoreFilesComment(extra map[string][]interface{}, igMessages
 		return false
 	}
 	for _, f := range extra["file"] {
-		fi := f.(config.FileInfo)
+		fi, ok := f.(config.FileInfo)
+		if !ok {
+			continue
+		}
 		if gw.ignoreText(fi.Comment, igMessages) {
 			return true
 		}

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -299,10 +299,24 @@ func (gw *Gateway) ignoreMessage(msg *config.Message) bool {
 
 	igNicks := strings.Fields(gw.Bridges[msg.Account].GetString("IgnoreNicks"))
 	igMessages := strings.Fields(gw.Bridges[msg.Account].GetString("IgnoreMessages"))
-	if gw.ignoreTextEmpty(msg) || gw.ignoreText(msg.Username, igNicks) || gw.ignoreText(msg.Text, igMessages) {
+	if gw.ignoreTextEmpty(msg) || gw.ignoreText(msg.Username, igNicks) || gw.ignoreText(msg.Text, igMessages) || gw.ignoreFilesComment(msg.Extra, igMessages) {
 		return true
 	}
 
+	return false
+}
+
+// ignoreFilesComment returns true if we need to ignore a file with matched comment.
+func (gw *Gateway) ignoreFilesComment(extra map[string][]interface{}, igMessages []string) bool {
+	if extra == nil {
+		return false
+	}
+	for _, f := range extra["file"] {
+		fi := f.(config.FileInfo)
+		if gw.ignoreText(fi.Comment, igMessages) {
+			return true
+		}
+	}
 	return false
 }
 


### PR DESCRIPTION
Now `IgnoreMessages` setting check and attached file comment too.

How I test it:
In Slack bridge configuration I set `IgnoreMessages="^~~"`

**Old Behavior:**
Sending message with attached file from Slack to Telegram with file comment "~~ test comment" sends this file to Telegram.

**New Behavior:**
Sending message with attached file from Slack to Telegram with file comment "~~ test comment" not sends this file to Telegram.