### PR TITLE
Change discord non-native threading behaviour

### DIFF
--- a/bridge/discord/discord.go
+++ b/bridge/discord/discord.go
@@ -272,7 +272,8 @@ func (b *Bdiscord) Send(msg config.Message) (string, error) {
 	// Handle prefix hint for unthreaded messages.
 	if msg.ParentNotFound() {
 		msg.ParentID = ""
-		msg.Text = fmt.Sprintf("[thread]: %s", msg.Text)
+		msg.Text = strings.TrimPrefix(msg.Text, "\n")
+		msg.Text = fmt.Sprintf("> %s %s", msg.Username, msg.Text)
 	}
 
 	// Use webhook to send the message


### PR DESCRIPTION
Sorta regression introduced by 9a8ce9b17e560433731eb5efa3cee7ced0b93605
which changes the way we get replies of matrix.

This causes issues like https://github.com/42wim/matterbridge/issues/1780
We "fix" this by mimicking the old behaviour when "PreserveThreading" is
disabled.