### PR TITLE
Improve Slack attachments formatting (slack)

### DIFF
--- a/bridge/slack/handlers.go
+++ b/bridge/slack/handlers.go
@@ -282,6 +282,14 @@ func (b *Bslack) handleStatusEvent(ev *slack.MessageEvent, rmsg *config.Message)
 	return false
 }
 
+func getMessageTitle(attach *slack.Attachment) string {
+	if attach.TitleLink != "" {
+		return fmt.Sprintf("[%s](%s)\n", attach.Title, attach.TitleLink)
+	} else {
+		return attach.Title
+	}
+}
+
 func (b *Bslack) handleAttachments(ev *slack.MessageEvent, rmsg *config.Message) {
 	// File comments are set by the system (because there is no username given).
 	if ev.SubType == sFileComment {
@@ -293,9 +301,12 @@ func (b *Bslack) handleAttachments(ev *slack.MessageEvent, rmsg *config.Message)
 		for _, attach := range ev.Attachments {
 			if attach.Text != "" {
 				if attach.Title != "" {
-					rmsg.Text = attach.Title + "\n"
+					rmsg.Text = getMessageTitle(&attach)
 				}
 				rmsg.Text += attach.Text
+				if attach.Footer != "" {
+					rmsg.Text += "\n\n" + attach.Footer
+				}
 			} else {
 				rmsg.Text = attach.Fallback
 			}

--- a/bridge/slack/handlers.go
+++ b/bridge/slack/handlers.go
@@ -285,9 +285,8 @@ func (b *Bslack) handleStatusEvent(ev *slack.MessageEvent, rmsg *config.Message)
 func getMessageTitle(attach *slack.Attachment) string {
 	if attach.TitleLink != "" {
 		return fmt.Sprintf("[%s](%s)\n", attach.Title, attach.TitleLink)
-	} else {
-		return attach.Title
 	}
+	return attach.Title
 }
 
 func (b *Bslack) handleAttachments(ev *slack.MessageEvent, rmsg *config.Message) {
@@ -298,10 +297,10 @@ func (b *Bslack) handleAttachments(ev *slack.MessageEvent, rmsg *config.Message)
 
 	// See if we have some text in the attachments.
 	if rmsg.Text == "" {
-		for _, attach := range ev.Attachments {
+		for i, attach := range ev.Attachments {
 			if attach.Text != "" {
 				if attach.Title != "" {
-					rmsg.Text = getMessageTitle(&attach)
+					rmsg.Text = getMessageTitle(&ev.Attachments[i])
 				}
 				rmsg.Text += attach.Text
 				if attach.Footer != "" {

--- a/bridge/slack/helpers.go
+++ b/bridge/slack/helpers.go
@@ -127,7 +127,7 @@ var (
 	mentionRE        = regexp.MustCompile(`<@([a-zA-Z0-9]+)>`)
 	channelRE        = regexp.MustCompile(`<#[a-zA-Z0-9]+\|(.+?)>`)
 	variableRE       = regexp.MustCompile(`<!((?:subteam\^)?[a-zA-Z0-9]+)(?:\|@?(.+?))?>`)
-	urlRE            = regexp.MustCompile(`<(.*?)(\|.*?)?>`)
+	urlRE            = regexp.MustCompile(`<([^<\|]+)\|([^>]+)>`)
 	codeFenceRE      = regexp.MustCompile(`(?m)^` + "```" + `\w+$`)
 	topicOrPurposeRE = regexp.MustCompile(`(?s)(@.+) (cleared|set)(?: the)? channel (topic|purpose)(?:: (.*))?`)
 )
@@ -181,14 +181,7 @@ func (b *Bslack) replaceVariable(text string) string {
 
 // @see https://api.slack.com/docs/message-formatting#linking_to_urls
 func (b *Bslack) replaceURL(text string) string {
-	for _, r := range urlRE.FindAllStringSubmatch(text, -1) {
-		if len(strings.TrimSpace(r[2])) == 1 { // A display text separator was found, but the text was blank
-			text = strings.Replace(text, r[0], "", 1)
-		} else {
-			text = strings.Replace(text, r[0], r[1], 1)
-		}
-	}
-	return text
+	return urlRE.ReplaceAllString(text, "[${2}](${1})")
 }
 
 func (b *Bslack) replaceb0rkedMarkDown(text string) string {


### PR DESCRIPTION
While I was tuning bridge between Slack and Mattermost, I faced with a problem, that Slack message with the attachment (not a file attachment, but a message, that bot or integration generates) lost `TitleLink` and `Footer` attributes at Mattermost. 

I made a quick fix for replacement of Slack link format `<link|text>` to Markdown format `[text](link)`, that could be a breaking change for other bridges that doesn't support Markdown format. Also add `Footer` to the result message.

Can be linked to #265 #474