### PR TITLE
Telegram: Do not apply any markup to URL entities

### DIFF
--- a/bridge/telegram/handlers.go
+++ b/bridge/telegram/handlers.go
@@ -517,8 +517,8 @@ func (b *Btelegram) handleEntities(rmsg *config.Message, message *tgbotapi.Messa
 	}
 
 	indexMovedBy := 0
+	prevLinkOffset := -1
 
-	// for now only do URL replacements
 	for _, e := range message.Entities {
 
 		asRunes := utf16.Encode([]rune(rmsg.Text))
@@ -537,6 +537,11 @@ func (b *Btelegram) handleEntities(rmsg *config.Message, message *tgbotapi.Messa
 			}
 			rmsg.Text = string(utf16.Decode(asRunes[:offset+e.Length])) + " (" + url.String() + ")" + string(utf16.Decode(asRunes[offset+e.Length:]))
 			indexMovedBy += len(url.String()) + 3
+			prevLinkOffset = e.Offset
+		}
+
+		if e.Offset == prevLinkOffset {
+			continue
 		}
 
 		if e.Type == "code" {


### PR DESCRIPTION
handleEntities code uses simple modification offset which does not
allow to detect whether the offset is placed before or after
the element in already modified string.
This works fine is most cases as Telegram server always sort the
elements by offset, in ascending order.
However, this is not the case when the modification, for example bold
text, is applied to the URL. In this case, the offset of URL and
bold entity is equal, which raises the issue.

This commit introduces additional hack for this case, stripping
any entities which intersect with URL.