### PR TITLE
Fix telegram message deletion request

### DIFF
--- a/bridge/telegram/handlers.go
+++ b/bridge/telegram/handlers.go
@@ -404,7 +404,7 @@ func (b *Btelegram) handleDelete(msg *config.Message, chatid int64) (string, err
 	}
 
 	cfg := tgbotapi.NewDeleteMessage(chatid, msgid)
-	_, err = b.c.Send(cfg)
+	_, err = b.c.Request(cfg)
 
 	return "", err
 }


### PR DESCRIPTION
This commit fix telegram message deletion behavior.

In old behavior Send method used, message deleted in telegram, but method will return error.

I changed it to [recommended way](https://github.com/go-telegram-bot-api/telegram-bot-api/issues/514).