### PR TITLE
Add KeepQuotedReply option for matrix to fix regression

### DIFF
--- a/bridge/discord/discord.go
+++ b/bridge/discord/discord.go
@@ -272,8 +272,6 @@ func (b *Bdiscord) Send(msg config.Message) (string, error) {
 	// Handle prefix hint for unthreaded messages.
 	if msg.ParentNotFound() {
 		msg.ParentID = ""
-		msg.Text = strings.TrimPrefix(msg.Text, "\n")
-		msg.Text = fmt.Sprintf("> %s %s", msg.Username, msg.Text)
 	}
 
 	// Use webhook to send the message

--- a/bridge/matrix/matrix.go
+++ b/bridge/matrix/matrix.go
@@ -428,12 +428,15 @@ func (b *Bmatrix) handleReply(ev *matrix.Event, rmsg config.Message) bool {
 	}
 
 	body := rmsg.Text
-	for strings.HasPrefix(body, "> ") {
-		lineIdx := strings.IndexRune(body, '\n')
-		if lineIdx == -1 {
-			body = ""
-		} else {
-			body = body[(lineIdx + 1):]
+
+	if !b.GetBool("keepquotedreply") {
+		for strings.HasPrefix(body, "> ") {
+			lineIdx := strings.IndexRune(body, '\n')
+			if lineIdx == -1 {
+				body = ""
+			} else {
+				body = body[(lineIdx + 1):]
+			}
 		}
 	}
 

--- a/bridge/mattermost/helpers.go
+++ b/bridge/mattermost/helpers.go
@@ -183,6 +183,7 @@ func (b *Bmattermost) sendWebhook(msg config.Message) (string, error) {
 	if b.GetBool("PrefixMessagesWithNick") {
 		msg.Text = msg.Username + msg.Text
 	}
+
 	if msg.Extra != nil {
 		// this sends a message only if we received a config.EVENT_FILE_FAILURE_SIZE
 		for _, rmsg := range helper.HandleExtra(&msg, b.General) {

--- a/matterbridge.toml.sample
+++ b/matterbridge.toml.sample
@@ -1328,6 +1328,15 @@ HTMLDisable=false
 # UseUserName shows the username instead of the server nickname
 UseUserName=false
 
+# Matrix quotes replies and as of matterbridge 1.24.0 we strip those as this causes
+# issues with bridges support threading and have PreserveThreading enabled.
+# But if you for example use mattermost or discord with webhooks you'll need to enable 
+# this (and keep PreserveThreading disabled) if you want something that looks like a reply from matrix.
+# See issues: 
+# - https://github.com/42wim/matterbridge/issues/1819
+# - https://github.com/42wim/matterbridge/issues/1780
+KeepQuotedReply=false
+
 #Nicks you want to ignore.
 #Regular expressions supported
 #Messages from those users will not be sent to other bridges.


### PR DESCRIPTION
Matrix quotes replies and as of matterbridge 1.24.0 we strip those as this causes
issues with bridges support threading and have PreserveThreading enabled.

Introduced via https://github.com/42wim/matterbridge/commit/9a8ce9b17e560433731eb5efa3cee7ced0b93605

But if you for example use mattermost or discord with webhooks you'll need to enable
this (and keep PreserveThreading false) if you want something that looks like a reply from matrix.

See issues:
- https://github.com/42wim/matterbridge/issues/1819
- https://github.com/42wim/matterbridge/issues/1780

Fixes https://github.com/42wim/matterbridge/issues/1806