### PR TITLE
discord: Ignore events from other guilds, add nosendjoinpart support

### DIFF
--- a/bridge/discord/discord.go
+++ b/bridge/discord/discord.go
@@ -83,12 +83,12 @@ func (b *Bdiscord) Connect() error {
 	b.Log.Info("Connection succeeded")
 	b.c.AddHandler(b.messageCreate)
 	b.c.AddHandler(b.messageTyping)
-	b.c.AddHandler(b.memberUpdate)
 	b.c.AddHandler(b.messageUpdate)
 	b.c.AddHandler(b.messageDelete)
 	b.c.AddHandler(b.messageDeleteBulk)
 	b.c.AddHandler(b.memberAdd)
 	b.c.AddHandler(b.memberRemove)
+	b.c.AddHandler(b.memberUpdate)
 	if b.GetInt("debuglevel") == 1 {
 		b.c.AddHandler(b.messageEvent)
 	}

--- a/bridge/discord/handlers.go
+++ b/bridge/discord/handlers.go
@@ -7,6 +7,10 @@ import (
 )
 
 func (b *Bdiscord) messageDelete(s *discordgo.Session, m *discordgo.MessageDelete) { //nolint:unparam
+	if m.GuildID != b.guildID {
+		b.Log.Debugf("Ignoring messageDelete because it originates from a different guild")
+		return
+	}
 	rmsg := config.Message{Account: b.Account, ID: m.ID, Event: config.EventMsgDelete, Text: config.EventMsgDelete}
 	rmsg.Channel = b.getChannelName(m.ChannelID)
 
@@ -17,6 +21,10 @@ func (b *Bdiscord) messageDelete(s *discordgo.Session, m *discordgo.MessageDelet
 
 // TODO(qaisjp): if other bridges support bulk deletions, it could be fanned out centrally
 func (b *Bdiscord) messageDeleteBulk(s *discordgo.Session, m *discordgo.MessageDeleteBulk) { //nolint:unparam
+	if m.GuildID != b.guildID {
+		b.Log.Debugf("Ignoring messageDeleteBulk because it originates from a different guild")
+		return
+	}
 	for _, msgID := range m.Messages {
 		rmsg := config.Message{
 			Account: b.Account,
@@ -37,6 +45,10 @@ func (b *Bdiscord) messageEvent(s *discordgo.Session, m *discordgo.Event) {
 }
 
 func (b *Bdiscord) messageTyping(s *discordgo.Session, m *discordgo.TypingStart) {
+	if m.GuildID != b.guildID {
+		b.Log.Debugf("Ignoring messageTyping because it originates from a different guild")
+		return
+	}
 	if !b.GetBool("ShowUserTyping") {
 		return
 	}
@@ -52,6 +64,10 @@ func (b *Bdiscord) messageTyping(s *discordgo.Session, m *discordgo.TypingStart)
 }
 
 func (b *Bdiscord) messageUpdate(s *discordgo.Session, m *discordgo.MessageUpdate) { //nolint:unparam
+	if m.GuildID != b.guildID {
+		b.Log.Debugf("Ignoring messageUpdate because it originates from a different guild")
+		return
+	}
 	if b.GetBool("EditDisable") {
 		return
 	}
@@ -67,6 +83,10 @@ func (b *Bdiscord) messageUpdate(s *discordgo.Session, m *discordgo.MessageUpdat
 }
 
 func (b *Bdiscord) messageCreate(s *discordgo.Session, m *discordgo.MessageCreate) { //nolint:unparam
+	if m.GuildID != b.guildID {
+		b.Log.Debugf("Ignoring messageCreate because it originates from a different guild")
+		return
+	}
 	var err error
 
 	// not relay our own messages
@@ -144,6 +164,10 @@ func (b *Bdiscord) messageCreate(s *discordgo.Session, m *discordgo.MessageCreat
 }
 
 func (b *Bdiscord) memberUpdate(s *discordgo.Session, m *discordgo.GuildMemberUpdate) {
+	if m.GuildID != b.guildID {
+		b.Log.Debugf("Ignoring memberUpdate because it originates from a different guild")
+		return
+	}
 	if m.Member == nil {
 		b.Log.Warnf("Received member update with no member information: %#v", m)
 	}
@@ -171,6 +195,10 @@ func (b *Bdiscord) memberUpdate(s *discordgo.Session, m *discordgo.GuildMemberUp
 }
 
 func (b *Bdiscord) memberAdd(s *discordgo.Session, m *discordgo.GuildMemberAdd) {
+	if m.GuildID != b.guildID {
+		b.Log.Debugf("Ignoring memberAdd because it originates from a different guild")
+		return
+	}
 	if b.GetBool("nosendjoinpart") {
 		return
 	}
@@ -195,6 +223,10 @@ func (b *Bdiscord) memberAdd(s *discordgo.Session, m *discordgo.GuildMemberAdd) 
 }
 
 func (b *Bdiscord) memberRemove(s *discordgo.Session, m *discordgo.GuildMemberRemove) {
+	if m.GuildID != b.guildID {
+		b.Log.Debugf("Ignoring memberRemove because it originates from a different guild")
+		return
+	}
 	if b.GetBool("nosendjoinpart") {
 		return
 	}

--- a/bridge/discord/handlers.go
+++ b/bridge/discord/handlers.go
@@ -171,6 +171,9 @@ func (b *Bdiscord) memberUpdate(s *discordgo.Session, m *discordgo.GuildMemberUp
 }
 
 func (b *Bdiscord) memberAdd(s *discordgo.Session, m *discordgo.GuildMemberAdd) {
+	if b.GetBool("nosendjoinpart") {
+		return
+	}
 	if m.Member == nil {
 		b.Log.Warnf("Received member update with no member information: %#v", m)
 		return
@@ -192,6 +195,9 @@ func (b *Bdiscord) memberAdd(s *discordgo.Session, m *discordgo.GuildMemberAdd) 
 }
 
 func (b *Bdiscord) memberRemove(s *discordgo.Session, m *discordgo.GuildMemberRemove) {
+	if b.GetBool("nosendjoinpart") {
+		return
+	}
 	if m.Member == nil {
 		b.Log.Warnf("Received member update with no member information: %#v", m)
 		return

--- a/matterbridge.toml.sample
+++ b/matterbridge.toml.sample
@@ -197,7 +197,7 @@ ShowJoinPart=false
 VerboseJoinPart=false
 
 #Do not send joins/parts to other bridges
-#Currently works for messages from the following bridges: irc, mattermost, slack
+#Currently works for messages from the following bridges: irc, mattermost, slack, discord
 #OPTIONAL (default false)
 NoSendJoinPart=false
 
@@ -496,7 +496,7 @@ RemoteNickFormat="[{PROTOCOL}] <{NICK}> "
 ShowJoinPart=false
 
 #Do not send joins/parts to other bridges
-#Currently works for messages from the following bridges: irc, mattermost, slack
+#Currently works for messages from the following bridges: irc, mattermost, slack, discord
 #OPTIONAL (default false)
 NoSendJoinPart=false
 
@@ -830,7 +830,7 @@ RemoteNickFormat="[{PROTOCOL}] <{NICK}> "
 ShowJoinPart=false
 
 #Do not send joins/parts to other bridges
-#Currently works for messages from the following bridges: irc, mattermost, slack
+#Currently works for messages from the following bridges: irc, mattermost, slack, discord
 #OPTIONAL (default false)
 NoSendJoinPart=false
 


### PR DESCRIPTION
- Filter all incoming discord events and ignore ones originating from Guild IDs other than the one we have configured. This is necessary because discord bots receive events for *all* discord guilds that they are present in. Fixes https://github.com/42wim/matterbridge/issues/1612
- Add support for `nosendjoinpart` to the discord bridge