### PR TITLE
Support mattermost v7

### DIFF
--- a/bridge/mattermost/mattermost.go
+++ b/bridge/mattermost/mattermost.go
@@ -52,7 +52,7 @@ func (b *Bmattermost) Connect() error {
 		return nil
 	}
 
-	if strings.HasPrefix(b.getVersion(), "6.") {
+	if strings.HasPrefix(b.getVersion(), "6.") || strings.HasPrefix(b.getVersion(), "7.") {
 		if !b.v6 {
 			b.v6 = true
 		}


### PR DESCRIPTION
Mattermost api (almost) didn't change between v6.7.x and v7.0
Everything should just work

- fixes #1850 