### PR TITLE
Fixed message html entities escaping when sending to Telegram

### DIFF
--- a/bridge/telegram/html.go
+++ b/bridge/telegram/html.go
@@ -2,7 +2,6 @@ package btelegram
 
 import (
 	"bytes"
-	"html"
 
 	"github.com/russross/blackfriday"
 )
@@ -24,8 +23,14 @@ func (options *customHTML) Paragraph(out *bytes.Buffer, text func() bool) {
 func (options *customHTML) BlockCode(out *bytes.Buffer, text []byte, lang string) {
 	out.WriteString("<pre>")
 
-	out.WriteString(html.EscapeString(string(text)))
+	out.WriteString(string(text))
 	out.WriteString("</pre>\n")
+}
+
+func (options *customHTML) CodeSpan(out *bytes.Buffer, text []byte) {
+	out.WriteString("<code>")
+	out.WriteString(string(text))
+	out.WriteString("</code>")
 }
 
 func (options *customHTML) Header(out *bytes.Buffer, text func() bool, level int, id string) {
@@ -39,6 +44,10 @@ func (options *customHTML) HRule(out *bytes.Buffer) {
 func (options *customHTML) BlockQuote(out *bytes.Buffer, text []byte) {
 	out.WriteString("> ")
 	out.Write(text)
+	out.WriteByte('\n')
+}
+
+func (options *customHTML) LineBreak(out *bytes.Buffer) {
 	out.WriteByte('\n')
 }
 

--- a/bridge/telegram/telegram.go
+++ b/bridge/telegram/telegram.go
@@ -101,7 +101,7 @@ func (b *Btelegram) Send(msg config.Message) (string, error) {
 	}
 
 	if b.GetString("MessageFormat") == HTMLFormat {
-		msg.Text = makeHTML(msg.Text)
+		msg.Text = makeHTML(html.EscapeString(msg.Text))
 	}
 
 	// Delete message


### PR DESCRIPTION
Hello!

If you send message (for example, from Slack) with following content to Telegram:
> ```I'm just <br /> unescaped html with ````<b>some</b> html```` inside code block```

Message will be failed to to send with following error:
`SendMessage failed: Bad Request: can't parse entities: Unsupported start tag "br" at byte offset`

This PR just fixes this issue with Telegram messages sending with message `MessageFormat="HTML"`.