### PR TITLE
Enhance IRC join/part message support

### DIFF
--- a/bridge/irc/handlers.go
+++ b/bridge/irc/handlers.go
@@ -296,6 +296,7 @@ func (b *Birc) handlePrivMsg(client *girc.Client, event girc.Event) {
 		b.activeUsers[event.Source.Name] = time.Now().Unix()
 	}
 	b.Remote <- rmsg
+	b.cleanActiveMap()
 }
 
 func (b *Birc) handleRunCommands() {

--- a/matterbridge.toml.sample
+++ b/matterbridge.toml.sample
@@ -191,6 +191,14 @@ RemoteNickFormat="[{PROTOCOL}] <{NICK}> "
 #OPTIONAL (default false)
 ShowJoinPart=false
 
+#Only show join/part/quit information for users who have been active recently.
+#OPTIONAL (default false)
+ShowActiveUserEvents=false
+
+#A user is considered active for ShowActiveUserEvents if they've spoken within this number of seconds.
+#OPTIONAL (default 1800, which is 30 minutes)
+ActivityTimeout=1800
+
 #Enable to show verbose users joins/parts (ident@host) from other bridges
 #Currently works for messages from the following bridges: irc
 #OPTIONAL (default false)


### PR DESCRIPTION
A help channel on my IRC network uses matterbridge to link to a help channel on a related Discord. We've noticed a problem where people on the Discord end will respond to help requests from users who've already left. Enabling join/part message support is an option, but it'd be excessively chatty if every join/part was shown.

This adds a new feature that will selectively show join/part/nick change/quit messages if either a user was active recently or the message is inherently important (i.e. kicks and kills.) New config options are **ShowActiveUserEvents** and **ActivityTimeout**, explained below in the sample config. It also addresses an issue in the original code where a quit message handler would send an invalid channel in the bridge message because IRC QUIT events aren't populated with a channel name. (Neither are nick changes, which are also supported now.)

This is literally the first thing I've ever written in Go. I attempted to make it consistent with both your code style and language idioms, but please let me know if there's anything that needs to be addressed.