### PR TITLE
Matrix username spoofing

### DIFF
--- a/bridge/matrix/helpers.go
+++ b/bridge/matrix/helpers.go
@@ -51,7 +51,7 @@ func interface2Struct(in interface{}, out interface{}) error {
 	return json.Unmarshal(jsonObj, out)
 }
 
-// getDisplayName retrieves the displayName for mxid, querying the homserver if the mxid is not in the cache.
+// getDisplayName retrieves the displayName for mxid, querying the homeserver if the mxid is not in the cache.
 func (b *Bmatrix) getDisplayName(mxid string) string {
 	if b.GetBool("UseUserName") {
 		return mxid[1:]

--- a/matterbridge.toml.sample
+++ b/matterbridge.toml.sample
@@ -1390,6 +1390,11 @@ RemoteNickFormat="[{PROTOCOL}] <{NICK}> "
 #OPTIONAL (default false)
 ShowJoinPart=false
 
+#Rename the bot in the current room to the username of the message
+#This will make an additional API request per message and will probably count towards rate limits
+#OPTIONAL (default false)
+SpoofUsername=false
+
 #StripNick only allows alphanumerical nicks. See https://github.com/42wim/matterbridge/issues/285
 #It will strip other characters from the nick
 #OPTIONAL (default false)


### PR DESCRIPTION
This implements username spoofing for Matrix similar to Discords webhooks.

Matterbridge will rename itself - *only in the room* - to the username of the message by using a room state event.
The equivalent in Element is `/myroomnick $nick`.
If the username already exists in the room then Element will show the mxid next to the username.

There's a new setting introduced for Matrix named `SpoofUsername=true` which defaults to `false`.

Caveats:
* This will make an additional API request per message. So if you're already near rate limits then this will probably rate limit you.
  This could be reduced a bit by caching the last messages username and only change the name when necessary.
* By default all nickname changes are shown inside the Element chat which looks ugly but *can be turned off per user globally*.

<details>
<summary>Comparison screenshots</summary>

### Default:
  ![image](https://user-images.githubusercontent.com/1408843/184882176-85cac21f-6459-4505-b194-fbf4f0a43821.png)
### This PR with default Element settings:
  ![image](https://user-images.githubusercontent.com/1408843/184880967-3a1933c1-e273-42cf-82ea-620e052850d3.png)
### This PR with nickname changes turned off locally:
  ![image](https://user-images.githubusercontent.com/1408843/184881044-903e02f7-4d78-487e-b59e-a6ed187c4225.png)
### Discord:
  ![image](https://user-images.githubusercontent.com/1408843/184882795-d83f9b06-d240-47d7-8f1e-8913d17558d8.png)

</details>