### PR TITLE
add the `beerchat` project (a minetest mod)

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ Used by the projects below. Feel free to make a PR to add your project to this l
 - [Vintage Story](https://github.com/NikkyAI/vs-matterbridge)
 - [ServUO-matterbridge](https://github.com/kuoushi/ServUO-Matterbridge) (A matterbridge connector for ServUO servers)
 - [ts-matterbridge](https://github.com/Archeb/ts-matterbridge) (Integrate teamspeak chat with matterbridge)
+- [beerchat](https://github.com/mt-mods/beerchat) (Matterbridge link for minetest)
 
 ## Chat with us
 


### PR DESCRIPTION
This PR adds a link to the `beerchat` project to the readme.
`beerchat` is a minetest mod that uses the matterbridge api (https://github.com/mt-mods/beerchat/blob/master/doc/matterbridge.md)

by the way: thanks to everybody involved in this project :heart: this is an awesome piece of software