### PR TITLE
Allow substitution of bot's nick in RunCommands

### DIFF
--- a/bridge/irc/handlers.go
+++ b/bridge/irc/handlers.go
@@ -243,6 +243,7 @@ func (b *Birc) handlePrivMsg(client *girc.Client, event girc.Event) {
 
 func (b *Birc) handleRunCommands() {
 	for _, cmd := range b.GetStringSlice("RunCommands") {
+		cmd = strings.ReplaceAll(cmd, "{BOTNICK}", b.Nick)
 		if err := b.i.Cmd.SendRaw(cmd); err != nil {
 			b.Log.Errorf("RunCommands %s failed: %s", cmd, err)
 		}

--- a/matterbridge.toml.sample
+++ b/matterbridge.toml.sample
@@ -122,10 +122,11 @@ RejoinDelay=0
 #Only works in IRC right now.
 ColorNicks=false
 
-#RunCommands allows you to send RAW irc commands after connection
+#RunCommands allows you to send RAW irc commands after connection.
+#The substring {BOTNICK} will be replaced with the bot's current nickname.
 #Array of strings
 #OPTIONAL (default empty)
-RunCommands=["PRIVMSG user hello","PRIVMSG chanserv something"]
+RunCommands=["PRIVMSG user hello","PRIVMSG chanserv something", "MODE {BOTNICK} +B"]
 
 #PingDelay specifies how long to wait to send a ping to the irc server.
 #You can use s for second, m for minute

--- a/matterbridge.toml.sample
+++ b/matterbridge.toml.sample
@@ -123,7 +123,7 @@ RejoinDelay=0
 ColorNicks=false
 
 #RunCommands allows you to send RAW irc commands after connection.
-#The substring {BOTNICK} will be replaced with the bot's current nickname.
+#The string {BOTNICK} (case sensitive) will be replaced with the bot's current nickname.
 #Array of strings
 #OPTIONAL (default empty)
 RunCommands=["PRIVMSG user hello","PRIVMSG chanserv something", "MODE {BOTNICK} +B"]


### PR DESCRIPTION
Necessary for setting modes on connect if the bot's main nick is taken.
**Not tested** because I'm currently testing my other PRs. Will test this one once the other two are merged. Please feel free to wait to merge, or to just go ahead if it looks good because it's a one-line code change.