### PR TITLE
Add StripQuote option (telegram)

### DIFF
--- a/bridge/config/config.go
+++ b/bridge/config/config.go
@@ -156,6 +156,7 @@ type Protocol struct {
 	SkipVersionCheck       bool       // mattermost
 	StripNick              bool       // all protocols
 	StripMarkdown          bool       // irc
+	StripQuote             bool       // telegram
 	SyncTopic              bool       // slack
 	TengoModifyMessage     string     // general
 	Team                   string     // mattermost, keybase

--- a/bridge/telegram/handlers.go
+++ b/bridge/telegram/handlers.go
@@ -114,6 +114,8 @@ func (b *Btelegram) handleQuoting(rmsg *config.Message, message *tgbotapi.Messag
 			quote := message.ReplyToMessage.Text
 			if quote == "" {
 				quote = message.ReplyToMessage.Caption
+			} else if b.GetBool("StripQuote") {
+				quote = strings.ReplaceAll(quote, "\n", " ")
 			}
 			rmsg.Text = b.handleQuote(rmsg.Text, usernameReply, quote)
 		}

--- a/matterbridge.toml.sample
+++ b/matterbridge.toml.sample
@@ -1146,6 +1146,10 @@ ShowJoinPart=false
 #OPTIONAL (default false)
 StripNick=false
 
+#Replace line breaks with spaces in quoted messages to avoid flooding
+#OPTIONAL (default false)
+StripQuote=false
+
 #Enable to show topic changes from other bridges
 #Only works hiding/show topic changes from slack bridge for now
 #OPTIONAL (default false)


### PR DESCRIPTION
Quoted messages are a good option, but sometimes they flood the chat when there are too many line breaks.
![image](https://user-images.githubusercontent.com/78786202/192088781-a862380e-b54b-4f21-a455-5d8bce599d8f.png)

With this PR:
![image](https://user-images.githubusercontent.com/78786202/192088810-f062bb43-8b2f-424f-9dba-e9786e7145b4.png)

Works better with `QuoteLengthLimit`:
![image](https://user-images.githubusercontent.com/78786202/192088918-3747de68-7a3b-4f93-a857-ba801e690424.png)
