### PR TITLE
Fix empty messages on IRC

### DIFF
--- a/bridge/helper/helper.go
+++ b/bridge/helper/helper.go
@@ -86,6 +86,12 @@ func GetSubLines(message string, maxLineLength int, clippingMessage string) []st
 
 	var lines []string
 	for _, line := range strings.Split(strings.TrimSpace(message), "\n") {
+		if line == "" {
+			// Prevent sending empty messages, so we'll skip this line
+			// if it has no content.
+			continue
+		}
+
 		if maxLineLength == 0 || len([]byte(line)) <= maxLineLength {
 			lines = append(lines, line)
 			continue


### PR DESCRIPTION
> ![image](https://user-images.githubusercontent.com/78786202/192113971-b5319fc5-5b93-4b22-aaec-3302e9b57779.png)

instead of:

> ![image](https://user-images.githubusercontent.com/78786202/192114016-c79b9b0d-450c-40bc-9aba-8dcb3222cb75.png)
