### PR TITLE
Fix telegram attachment comment formatting and escaping

### DIFF
--- a/bridge/telegram/handlers.go
+++ b/bridge/telegram/handlers.go
@@ -451,6 +451,11 @@ func (b *Btelegram) handleUploadFile(msg *config.Message, chatid int64, parentID
 			Name:  fi.Name,
 			Bytes: *fi.Data,
 		}
+
+		if b.GetString("MessageFormat") == HTMLFormat {
+			fi.Comment = makeHTML(html.EscapeString(fi.Comment))
+		}
+
 		switch filepath.Ext(fi.Name) {
 		case ".jpg", ".jpe", ".png":
 			pc := tgbotapi.NewInputMediaPhoto(file)


### PR DESCRIPTION
Bugfix for telegram attachment comment formatting and escaping.

**How to reproduce this bug:**
You need bridge from slack to telegram.
Just send attachment with url in comment - message with attachment will not reach telegram.
