### PR TITLE
Handle incoming document captions from whatsapp

### DIFF
--- a/bridge/whatsappmulti/handlers.go
+++ b/bridge/whatsappmulti/handlers.go
@@ -335,7 +335,7 @@ func (b *Bwhatsapp) handleDocumentMessage(msg *events.Message) {
 	}
 
 	// Move file to bridge storage
-	helper.HandleDownloadData(b.Log, &rmsg, filename, "document", "", &data, b.General)
+	helper.HandleDownloadData(b.Log, &rmsg, filename, imsg.GetCaption(), "", &data, b.General)
 
 	b.Log.Debugf("<= Sending message from %s on %s to gateway", senderJID, b.Account)
 	b.Log.Debugf("<= Message is %#v", rmsg)


### PR DESCRIPTION
Whatsapp document attachments may now have captions. Basically #1928 or #1927 but to the another direction.