### PR TITLE
Make the cgo lottie a build tag (-tag cgolottie)

### DIFF
--- a/bridge/helper/libtgsconverter.go
+++ b/bridge/helper/libtgsconverter.go
@@ -1,5 +1,4 @@
-//go:build cgo
-// +build cgo
+//go:build cgolottie
 
 package helper
 

--- a/bridge/helper/lottie_convert.go
+++ b/bridge/helper/lottie_convert.go
@@ -1,4 +1,4 @@
-// +build !cgo
+//go:build !cgolottie
 
 package helper
 
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
+
 	"github.com/sirupsen/logrus"
 )
 


### PR DESCRIPTION
This should fix #1906 as we don't have any cgo dependencies anymore by default.