### PR TITLE
Bugfix: handle messages with link preview not being relayed

### DIFF
--- a/bridge/whatsappmulti/handlers.go
+++ b/bridge/whatsappmulti/handlers.go
@@ -63,6 +63,10 @@ func (b *Bwhatsapp) handleTextMessage(messageInfo types.MessageInfo, msg *proto.
 	// nolint:nestif
 	if msg.GetExtendedTextMessage() == nil {
 		text = msg.GetConversation()
+	} else if msg.GetExtendedTextMessage().GetContextInfo() == nil {
+		// Handle pure text message with a link preview
+		// A pure text message with a link preview acts as an extended text message but will not contain any context info
+		text = msg.GetExtendedTextMessage().GetText()
 	} else {
 		text = msg.GetExtendedTextMessage().GetText()
 		ci := msg.GetExtendedTextMessage().GetContextInfo()


### PR DESCRIPTION
A message containing only text + a link preview will contain ExtendedTextMessage information.
However, it will not contain message context from `GetContextInfo()` hence the null dereference when we try to check for and resolve @mentions

Previous behavior was that a message with a link preview would NOT fail to send.

Resolves #1840

![image](https://user-images.githubusercontent.com/36427684/219319226-81ffea1f-7ece-4825-9e4e-dd7c325828a4.png)
