### PR TITLE
Bugfix: whatsappmulti prefer mp4 extension for video attachments

### DIFF
--- a/bridge/whatsappmulti/handlers.go
+++ b/bridge/whatsappmulti/handlers.go
@@ -207,7 +207,16 @@ func (b *Bwhatsapp) handleVideoMessage(msg *events.Message) {
 		fileExt = append(fileExt, ".mp4")
 	}
 
-	filename := fmt.Sprintf("%v%v", msg.Info.ID, fileExt[0])
+	// Prefer .mp4 extension, otherwise fallback to first index
+	fileExtIndex := 0
+	for i, n := range fileExt {
+		if ".mp4" == n {
+			fileExtIndex = i
+			break
+		}
+	}
+
+	filename := fmt.Sprintf("%v%v", msg.Info.ID, fileExt[fileExtIndex])
 
 	b.Log.Debugf("Trying to download %s with size %#v and type %s", filename, imsg.GetFileLength(), imsg.GetMimetype())
 


### PR DESCRIPTION
Resolves #1967

Question from issue still stands, will we ever expect not never receive a .mp4 typed video?
If not, then why don't we always force .mp4 like we do for `.jfif` and `.jpe`?

![image](https://user-images.githubusercontent.com/36427684/218989593-811205c6-f2ec-4dfd-bb27-6dc792592a29.png)