### PR TITLE
Allow message deletes from any platform

### DIFF
--- a/bridge/whatsappmulti/whatsapp.go
+++ b/bridge/whatsappmulti/whatsapp.go
@@ -361,7 +361,7 @@ func (b *Bwhatsapp) Send(msg config.Message) (string, error) {
 			return "", nil
 		}
 
-		_, err := b.wc.RevokeMessage(groupJID, msg.ID)
+		_, err := b.wc.SendMessage(context.Background(), groupJID, b.wc.BuildRevoke(groupJID, extendedMsgID.Sender, extendedMsgID.MessageID))
 
 		return "", err
 	}

--- a/gateway/gateway.go
+++ b/gateway/gateway.go
@@ -466,7 +466,8 @@ func (gw *Gateway) SendMessage(
 
 	// exclude file delete event as the msg ID here is the native file ID that needs to be deleted
 	if msg.Event != config.EventFileDelete {
-		msg.ID = gw.getDestMsgID(rmsg.Protocol+" "+rmsg.ID, dest, channel)
+		canonicalMsgID := gw.FindCanonicalMsgID(rmsg.Protocol, rmsg.ID)
+		msg.ID = gw.getDestMsgID(canonicalMsgID, dest, channel)
 	}
 
 	// for api we need originchannel as channel

--- a/gateway/router.go
+++ b/gateway/router.go
@@ -134,8 +134,9 @@ func (r *Router) handleReceive() {
 		r.handleEventFailure(&msg)
 		r.handleEventRejoinChannels(&msg)
 
+		srcBridge := r.getBridge(msg.Account)
 		// Set message protocol based on the account it came from
-		msg.Protocol = r.getBridge(msg.Account).Protocol
+		msg.Protocol = srcBridge.Protocol
 
 		filesHandled := false
 		for _, gw := range r.Gateways {
@@ -163,6 +164,11 @@ func (r *Router) handleReceive() {
 				// This is necessary as msgIDs will change if a bridge returns
 				// a different ID in response to edits.
 				if !exists {
+					// we're adding the original message as a "dest message"
+					// as when we get the dest messages for a delete the source message isnt in the list
+					// therefore the delete doesnt happen on the source platform.
+					msgIDs = append(msgIDs, &BrMsgID{srcBridge, srcBridge.Protocol + " " + msg.ID, msg.Channel + srcBridge.Account})
+
 					gw.Messages.Add(msg.Protocol+" "+msg.ID, msgIDs)
 				}
 			}


### PR DESCRIPTION
Allow message deletes from any platform

This allows for message deletes to be synced from any of the gateway's channels, not just the "canonical"/source channel.

Note, the required changes in whatsappmulti handler depends on #1974 
This is because when deleting a message that is not from the matterbridge user the sender jid is also required.