### PR TITLE
Fix Android media download problem (Whatsapp)

### DIFF
--- a/bridge/whatsappmulti/whatsapp.go
+++ b/bridge/whatsappmulti/whatsapp.go
@@ -243,6 +243,7 @@ func (b *Bwhatsapp) PostDocumentMessage(msg config.Message, filetype string) (st
 		FileSha256:    resp.FileSHA256,
 		FileLength:    goproto.Uint64(resp.FileLength),
 		Url:           &resp.URL,
+		DirectPath:    &resp.DirectPath,
 		ContextInfo:   ctx,
 	}
 
@@ -280,6 +281,7 @@ func (b *Bwhatsapp) PostImageMessage(msg config.Message, filetype string) (strin
 		FileSha256:    resp.FileSHA256,
 		FileLength:    goproto.Uint64(resp.FileLength),
 		Url:           &resp.URL,
+		DirectPath:    &resp.DirectPath,
 		ContextInfo:   ctx,
 	}
 
@@ -313,6 +315,7 @@ func (b *Bwhatsapp) PostVideoMessage(msg config.Message, filetype string) (strin
 		FileSha256:    resp.FileSHA256,
 		FileLength:    goproto.Uint64(resp.FileLength),
 		Url:           &resp.URL,
+		DirectPath:    &resp.DirectPath,
 		ContextInfo:   ctx,
 	}
 
@@ -345,6 +348,7 @@ func (b *Bwhatsapp) PostAudioMessage(msg config.Message, filetype string) (strin
 		FileSha256:    resp.FileSHA256,
 		FileLength:    goproto.Uint64(resp.FileLength),
 		Url:           &resp.URL,
+		DirectPath:    &resp.DirectPath,
 		ContextInfo:   ctx,
 	}
 


### PR DESCRIPTION
The most recent Android clients need the DirectPath to be provided in order to successfully download attachments. Closes #2005.