### PR TITLE
Add Tengo script to autolink on Mumble

### DIFF
--- a/contrib/mumble-autolink.tengo
+++ b/contrib/mumble-autolink.tengo
@@ -1,0 +1,6 @@
+text := import("text")
+
+if outProtocol == "mumble" {
+    urlRE := text.re_compile(`(?is)((http|https):\/\/)?([a-z0-9-]+\.)?[a-z0-9-]+(\.[a-z]{2,6}){1,3}(\/[a-z0-9.,_\/~#&=;%+?-]*)?`)
+    msgText = urlRE.replace(msgText,`<a href="$0">$0</a>`)
+}


### PR DESCRIPTION
I've thought of adding this to the internal Tengo script but I'll just upload it to contrib folder for now.