### PR TITLE
[Bugfix] Add nil check for group update in telegram

### DIFF
--- a/bridge/telegram/handlers.go
+++ b/bridge/telegram/handlers.go
@@ -264,13 +264,13 @@ func (b *Btelegram) handleRecv(updates <-chan tgbotapi.Update) {
 }
 
 func (b *Btelegram) handleGroupUpdate(update tgbotapi.Update) {
-	msg := update.Message
-
-	switch {
-	case msg.NewChatMembers != nil:
-		b.handleUserJoin(update)
-	case msg.LeftChatMember != nil:
-		b.handleUserLeave(update)
+	if msg := update.Message; msg != nil {
+		switch {
+		case msg.NewChatMembers != nil:
+			b.handleUserJoin(update)
+		case msg.LeftChatMember != nil:
+			b.handleUserLeave(update)
+		}
 	}
 }
 


### PR DESCRIPTION
Fix bug in telegram handler from #2019 

Some group updates actually have a nil message so the current usage may throw an exception.