### PR TITLE
trim nick whitespace when looking up the guild members

### DIFF
--- a/bridge/discord/helpers.go
+++ b/bridge/discord/helpers.go
@@ -68,7 +68,7 @@ func (b *Bdiscord) getGuildMemberByNick(nick string) (*discordgo.Member, error) 
 	b.membersMutex.RLock()
 	defer b.membersMutex.RUnlock()
 
-	if member, ok := b.nickMemberMap[nick]; ok {
+	if member, ok := b.nickMemberMap[strings.TrimSpace(nick)]; ok {
 		return member, nil
 	}
 	return nil, errors.New("Couldn't find guild member with nick " + nick) // This will most likely get ignored by the caller


### PR DESCRIPTION
This fixes the matching to attempt to find avatars. I will note I am not a Go developer or familiar with matterbridge, so there may be a better place to do this.

fixes #2059