### PR TITLE
Fix typos in matterbridge.toml.sample

### DIFF
--- a/matterbridge.toml.sample
+++ b/matterbridge.toml.sample
@@ -163,7 +163,7 @@ IgnoreMessages="^~~ badword"
 ReplaceMessages=[ ["cat","dog"] ]
 
 #nicks you want to replace.
-#see replacemessages for syntaxa
+#see replacemessages for syntax
 #optional (default empty)
 ReplaceNicks=[ ["user--","user"] ]
 
@@ -301,7 +301,7 @@ IgnoreMessages="^~~ badword"
 ReplaceMessages=[ ["cat","dog"] ]
 
 #Nicks you want to replace.
-#See ReplaceMessages for syntaxA
+#See ReplaceMessages for syntax
 #OPTIONAL (default empty)
 ReplaceNicks=[ ["user--","user"] ]
 
@@ -468,7 +468,7 @@ IgnoreMessages="^~~ badword"
 ReplaceMessages=[ ["cat","dog"] ]
 
 #nicks you want to replace.
-#see replacemessages for syntaxa
+#see replacemessages for syntax
 #optional (default empty)
 ReplaceNicks=[ ["user--","user"] ]
 
@@ -586,7 +586,7 @@ IgnoreMessages="^~~ badword"
 ReplaceMessages=[ ["cat","dog"] ]
 
 #nicks you want to replace.
-#see replacemessages for syntaxa
+#see replacemessages for syntax
 #optional (default empty)
 ReplaceNicks=[ ["user--","user"] ]
 
@@ -725,7 +725,7 @@ IgnoreMessages="^~~ badword"
 ReplaceMessages=[ ["cat","dog"] ]
 
 #nicks you want to replace.
-#see replacemessages for syntaxa
+#see replacemessages for syntax
 #optional (default empty)
 ReplaceNicks=[ ["user--","user"] ]
 
@@ -1033,7 +1033,7 @@ IgnoreMessages="^~~ badword"
 ReplaceMessages=[ ["cat","dog"] ]
 
 #nicks you want to replace.
-#see replacemessages for syntaxa
+#see replacemessages for syntax
 #optional (default empty)
 ReplaceNicks=[ ["user--","user"] ]
 
@@ -1174,7 +1174,7 @@ IgnoreMessages="^~~ badword"
 ReplaceMessages=[ ["cat","dog"] ]
 
 #nicks you want to replace.
-#see replacemessages for syntaxa
+#see replacemessages for syntax
 #optional (default empty)
 ReplaceNicks=[ ["user--","user"] ]
 
@@ -1286,7 +1286,7 @@ IgnoreMessages="^~~ badword"
 ReplaceMessages=[ ["cat","dog"] ]
 
 #nicks you want to replace.
-#see replacemessages for syntaxa
+#see replacemessages for syntax
 #optional (default empty)
 ReplaceNicks=[ ["user--","user"] ]
 
@@ -1383,7 +1383,7 @@ IgnoreMessages="^~~ badword"
 ReplaceMessages=[ ["cat","dog"] ]
 
 #nicks you want to replace.
-#see replacemessages for syntaxa
+#see replacemessages for syntax
 #optional (default empty)
 ReplaceNicks=[ ["user--","user"] ]
 
@@ -1592,7 +1592,7 @@ IgnoreMessages="^~~ badword"
 ReplaceMessages=[ ["cat","dog"] ]
 
 #nicks you want to replace.
-#see replacemessages for syntaxa
+#see replacemessages for syntax
 #optional (default empty)
 ReplaceNicks=[ ["user--","user"] ]
 


### PR DESCRIPTION
Hello! I was exploring this example config file and found the word "syntaxa" in 10 places. I suppose it is a typo and there should be "syntax" instead of "syntaxa"