### PR TITLE
irc: do not bridge CTCP commands other than ACTION

### DIFF
--- a/bridge/irc/handlers.go
+++ b/bridge/irc/handlers.go
@@ -123,7 +123,6 @@ func (b *Birc) handleNewConnection(client *girc.Client, event girc.Event) {
 	b.Nick = event.Params[0]
 
 	i.Handlers.AddBg("PRIVMSG", b.handlePrivMsg)
-	i.Handlers.AddBg("CTCP_ACTION", b.handlePrivMsg)
 	i.Handlers.Add(girc.RPL_TOPICWHOTIME, b.handleTopicWhoTime)
 	i.Handlers.AddBg(girc.NOTICE, b.handleNotice)
 	i.Handlers.AddBg("JOIN", b.handleJoinPart)
@@ -195,7 +194,11 @@ func (b *Birc) handlePrivMsg(client *girc.Client, event girc.Event) {
 	b.Log.Debugf("== Receiving PRIVMSG: %s %s %#v", event.Source.Name, event.Last(), event)
 
 	// set action event
-	if event.IsAction() {
+	if ok, ctcp := event.IsCTCP(); ok {
+		if ctcp.Command != girc.CTCP_ACTION {
+			b.Log.Debugf("dropping user ctcp, command: %s", ctcp.Command)
+			return
+		}
 		rmsg.Event = config.EventUserAction
 	}
 


### PR DESCRIPTION
CTCP commands other than ACTION are designed for client-to-client interaction on IRC networks. Drop such messages when we receive them.

Also get rid of a "CTCP_ACTION" handler in the handler registration. The registration

1) can't do anything (if anything, we wanted the string constant
   girc.CTCP_ACTION, which is "ACTION")
2) doesn't do anything in this context, because CTCP handlers are
   registered separately:
   https://github.com/lrstanley/girc/blob/f47717952bf9258e02eac14f1b9723bcf084e618/ctcp.go#L205

The PRIVMSG handler already listens to all CTCPs.

Thanks to @lexande for the bug report (found on a live instance).