### PR TITLE
Optionally send file URL instead of uploading media from Matrix messages

### DIFF
--- a/bridge/config/config.go
+++ b/bridge/config/config.go
@@ -146,6 +146,7 @@ type Protocol struct {
 	ReplaceNicks           [][]string // all protocols
 	RemoteNickFormat       string     // all protocols
 	RunCommands            []string   // IRC
+	SendUrlNotFile         bool       // matrix
 	Server                 string     // IRC,mattermost,XMPP,discord,matrix
 	SessionFile            string     // msteams,whatsapp
 	ShowJoinPart           bool       // all protocols

--- a/bridge/matrix/matrix.go
+++ b/bridge/matrix/matrix.go
@@ -540,9 +540,18 @@ func (b *Bmatrix) handleEvent(ev *matrix.Event) {
 
 		// Do we have attachments
 		if b.containsAttachment(ev.Content) {
-			err := b.handleDownloadFile(&rmsg, ev.Content)
-			if err != nil {
-				b.Log.Errorf("download failed: %#v", err)
+			if b.GetBool("SendUrlNotFile") {
+				// replace the text of the message (which is set to the filename above) with the url
+				var err error
+				rmsg.Text, err = b.getMessageFileUrl(ev.Content)
+				if err != nil {
+					b.Log.Errorf("get url for uploaded file failed: %#v", err)
+				}
+			} else {
+				err := b.handleDownloadFile(&rmsg, ev.Content)
+				if err != nil {
+					b.Log.Errorf("download failed: %#v", err)
+				}
 			}
 		}
 

--- a/bridge/matrix/matrix.go
+++ b/bridge/matrix/matrix.go
@@ -556,6 +556,21 @@ func (b *Bmatrix) handleEvent(ev *matrix.Event) {
 	}
 }
 
+// getMessageFileUrl changes the Matrix mxc:// uploads and changes them to a regular url
+func (b *Bmatrix) getMessageFileUrl(content map[string]interface{}) (string, error) {
+	var (
+		ok  bool
+		url string
+	)
+
+	if url, ok = content["url"].(string); !ok {
+		return "", fmt.Errorf("url isn't a %T", url)
+	}
+	url = strings.Replace(url, "mxc://", b.GetString("Server")+"/_matrix/media/v1/download/", -1)
+
+	return url, nil
+}
+
 // handleDownloadFile handles file download
 func (b *Bmatrix) handleDownloadFile(rmsg *config.Message, content map[string]interface{}) error {
 	var (
@@ -566,10 +581,17 @@ func (b *Bmatrix) handleDownloadFile(rmsg *config.Message, content map[string]in
 	)
 
 	rmsg.Extra = make(map[string][]interface{})
-	if url, ok = content["url"].(string); !ok {
-		return fmt.Errorf("url isn't a %T", url)
+
+	//// moved to getMessageFileUrl
+	//if url, ok = content["url"].(string); !ok {
+	//	return fmt.Errorf("url isn't a %T", url)
+	//}
+	//url = strings.Replace(url, "mxc://", b.GetString("Server")+"/_matrix/media/v1/download/", -1)
+
+	url, err := b.getMessageFileUrl(content)
+	if err != nil {
+		return err
 	}
-	url = strings.Replace(url, "mxc://", b.GetString("Server")+"/_matrix/media/v1/download/", -1)
 
 	if info, ok = content["info"].(map[string]interface{}); !ok {
 		return fmt.Errorf("info isn't a %T", info)
@@ -601,7 +623,7 @@ func (b *Bmatrix) handleDownloadFile(rmsg *config.Message, content map[string]in
 	}
 
 	// check if the size is ok
-	err := helper.HandleDownloadSize(b.Log, rmsg, name, int64(size), b.General)
+	err = helper.HandleDownloadSize(b.Log, rmsg, name, int64(size), b.General)
 	if err != nil {
 		return err
 	}

--- a/matterbridge.toml.sample
+++ b/matterbridge.toml.sample
@@ -1330,7 +1330,8 @@ StripNick=false
 ShowTopicChange=false
 
 #Enable to send a URL rather than an image
-#(the default behavior in Matterbridge is to download and send a file)
+#The default behavior is to download and send/upload the file.
+#OPTIONAL (default false)
 #SendUrlNotFile=true
 
 ###################################################################

--- a/matterbridge.toml.sample
+++ b/matterbridge.toml.sample
@@ -1329,6 +1329,10 @@ StripNick=false
 #OPTIONAL (default false)
 ShowTopicChange=false
 
+#Enable to send a URL rather than an image
+#(the default behavior in Matterbridge is to download and send a file)
+SendUrlNotFile=true
+
 ###################################################################
 #steam section
 ###################################################################

--- a/matterbridge.toml.sample
+++ b/matterbridge.toml.sample
@@ -1331,7 +1331,7 @@ ShowTopicChange=false
 
 #Enable to send a URL rather than an image
 #(the default behavior in Matterbridge is to download and send a file)
-SendUrlNotFile=true
+#SendUrlNotFile=true
 
 ###################################################################
 #steam section


### PR DESCRIPTION
When bridging Matrix rooms to other services, optionally send URLs to the media or file in the message rather than uploading the files directly.

To enable, add `SendUrlNotFile=true` to the config file under the Matrix server's settings (added to `matterbridge.toml.sample`).