### PR TITLE
Discord: Split messages if necessary

### DIFF
--- a/bridge/config/config.go
+++ b/bridge/config/config.go
@@ -121,6 +121,7 @@ type Protocol struct {
 	MessageLength          int        // IRC, max length of a message allowed
 	MessageQueue           int        // IRC, size of message queue for flood control
 	MessageSplit           bool       // IRC, split long messages with newlines on MessageLength instead of clipping
+	MessageSplitMaxCount   int        // discord, split long messages into at most this many messages instead of clipping (MessageLength=1950 cannot be configured)
 	Muc                    string     // xmpp
 	MxID                   string     // matrix
 	Name                   string     // all protocols

--- a/bridge/discord/discord.go
+++ b/bridge/discord/discord.go
@@ -316,6 +316,7 @@ func (b *Bdiscord) handleEventBotUser(msg *config.Message, channelID string) (st
 	// Upload a file if it exists
 	if msg.Extra != nil {
 		for _, rmsg := range helper.HandleExtra(msg, b.General) {
+			// TODO: Use ClipOrSplitMessage
 			rmsg.Text = helper.ClipMessage(rmsg.Text, MessageLength, b.GetString("MessageClipped"))
 			if _, err := b.c.ChannelMessageSend(channelID, rmsg.Username+rmsg.Text); err != nil {
 				b.Log.Errorf("Could not send message %#v: %s", rmsg, err)
@@ -327,35 +328,53 @@ func (b *Bdiscord) handleEventBotUser(msg *config.Message, channelID string) (st
 		}
 	}
 
-	msg.Text = helper.ClipMessage(msg.Text, MessageLength, b.GetString("MessageClipped"))
-	msg.Text = b.replaceUserMentions(msg.Text)
-
 	// Edit message
 	if msg.ID != "" {
-		_, err := b.c.ChannelMessageEdit(channelID, msg.ID, msg.Username+msg.Text)
-		return msg.ID, err
-	}
-
-	m := discordgo.MessageSend{
-		Content:         msg.Username + msg.Text,
-		AllowedMentions: b.getAllowedMentions(),
-	}
-
-	if msg.ParentValid() {
-		m.Reference = &discordgo.MessageReference{
-			MessageID: msg.ParentID,
-			ChannelID: channelID,
-			GuildID:   b.guildID,
+		// Exploit that a discord message ID is actually just a large number, and we encode a list of IDs by separating them with ";".
+		var msgIds = strings.Split(msg.ID, ";")
+		msgParts := helper.ClipOrSplitMessage(b.replaceUserMentions(msg.Text), MessageLength, b.GetString("MessageClipped"), len(msgIds))
+		for len(msgParts) < len(msgIds) {
+			msgParts = append(msgParts, "((obsoleted by edit))")
 		}
+		for i := range msgParts {
+			// In case of split-messages where some parts remain the same (i.e. only a typo-fix in a huge message), this causes some noop-updates.
+			// TODO: Optimize away noop-updates of un-edited messages
+			// TODO: Use RemoteNickFormat instead of this broken concatenation
+			_, err := b.c.ChannelMessageEdit(channelID, msgIds[i], msg.Username+msgParts[i])
+			if err != nil {
+				return "", err
+			}
+		}
+		return msg.ID, nil
 	}
 
-	// Post normal message
-	res, err := b.c.ChannelMessageSendComplex(channelID, &m)
-	if err != nil {
-		return "", err
+	msgParts := helper.ClipOrSplitMessage(b.replaceUserMentions(msg.Text), MessageLength, b.GetString("MessageClipped"), b.GetInt("MessageSplitMaxCount"))
+	var msgIds = []string{}
+
+	for _, msgPart := range msgParts {
+		m := discordgo.MessageSend{
+			Content:         msg.Username + msgPart,
+			AllowedMentions: b.getAllowedMentions(),
+		}
+
+		if msg.ParentValid() {
+			m.Reference = &discordgo.MessageReference{
+				MessageID: msg.ParentID,
+				ChannelID: channelID,
+				GuildID:   b.guildID,
+			}
+		}
+
+		// Post normal message
+		res, err := b.c.ChannelMessageSendComplex(channelID, &m)
+		if err != nil {
+			return "", err
+		}
+		msgIds = append(msgIds, res.ID)
 	}
 
-	return res.ID, nil
+	// Exploit that a discord message ID is actually just a large number, so we encode a list of IDs by separating them with ";".
+	return strings.Join(msgIds, ";"), nil
 }
 
 // handleUploadFile handles native upload of files

--- a/bridge/helper/helper.go
+++ b/bridge/helper/helper.go
@@ -219,6 +219,33 @@ func ClipMessage(text string, length int, clippingMessage string) string {
 	return text
 }
 
+func ClipOrSplitMessage(text string, length int, clippingMessage string, splitMax int) []string {
+	var msgParts []string
+	var remainingText = text
+	// Invariant of this splitting loop: No text is lost (msgParts+remainingText is the original text),
+	// and all parts is guaranteed to satisfy the length requirement.
+	for len(msgParts) < splitMax - 1 && len(remainingText) > length {
+		// Decision: The text needs to be split (again).
+		var chunk string
+		var wasted = 0
+		// The longest UTF-8 encoding of a valid rune is 4 bytes (0xF4 0x8F 0xBF 0xBF, encoding U+10FFFF),
+		// so we should never need to waste 4 or more bytes at a time.
+		for wasted < 4 && wasted < length {
+			chunk = remainingText[:length - wasted]
+			if r, _ := utf8.DecodeLastRuneInString(chunk); r == utf8.RuneError {
+				wasted += 1
+			} else {
+				break
+			}
+		}
+		// Note: At this point, "chunk" might still be invalid, if "text" is very broken.
+		msgParts = append(msgParts, chunk)
+		remainingText = remainingText[len(chunk):]
+	}
+	msgParts = append(msgParts, ClipMessage(remainingText, length, clippingMessage))
+	return msgParts
+}
+
 // ParseMarkdown takes in an input string as markdown and parses it to html
 func ParseMarkdown(input string) string {
 	extensions := parser.HardLineBreak | parser.NoIntraEmphasis | parser.FencedCode

--- a/bridge/helper/helper_test.go
+++ b/bridge/helper/helper_test.go
@@ -125,3 +125,105 @@ func TestConvertWebPToPNG(t *testing.T) {
 		t.Fail()
 	}
 }
+
+var clippingOrSplittingTestCases = map[string]struct {
+	inputText       string
+	clipSplitLength int
+	clippingMessage string
+	splitMax        int
+	expectedOutput  []string
+}{
+	"Short single-line message, split 3": {
+		inputText:       "short",
+		clipSplitLength: 20,
+		clippingMessage: "?!?!",
+		splitMax:        3,
+		expectedOutput:  []string{"short"},
+	},
+	"Short single-line message, split 1": {
+		inputText:       "short",
+		clipSplitLength: 20,
+		clippingMessage: "?!?!",
+		splitMax:        1,
+		expectedOutput:  []string{"short"},
+	},
+	"Short single-line message, split 0": {
+		// Mainly check that we don't crash.
+		inputText:       "short",
+		clipSplitLength: 20,
+		clippingMessage: "?!?!",
+		splitMax:        0,
+		expectedOutput:  []string{"short"},
+	},
+	"Long single-line message, noclip": {
+		inputText:       "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
+		clipSplitLength: 50,
+		clippingMessage: "?!?!",
+		splitMax:        10,
+		expectedOutput:  []string{
+			"Lorem ipsum dolor sit amet, consectetur adipiscing",
+			" elit, sed do eiusmod tempor incididunt ut labore ",
+			"et dolore magna aliqua.",
+		},
+	},
+	"Long single-line message, noclip tight": {
+		inputText:       "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
+		clipSplitLength: 50,
+		clippingMessage: "?!?!",
+		splitMax:        3,
+		expectedOutput:  []string{
+			"Lorem ipsum dolor sit amet, consectetur adipiscing",
+			" elit, sed do eiusmod tempor incididunt ut labore ",
+			"et dolore magna aliqua.",
+		},
+	},
+	"Long single-line message, clip custom": {
+		inputText:       "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
+		clipSplitLength: 50,
+		clippingMessage: "?!?!",
+		splitMax:        2,
+		expectedOutput:  []string{
+			"Lorem ipsum dolor sit amet, consectetur adipiscing",
+			" elit, sed do eiusmod tempor incididunt ut lab?!?!",
+		},
+	},
+	"Long single-line message, clip built-in": {
+		inputText:       "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
+		clipSplitLength: 50,
+		clippingMessage: "",
+		splitMax:        2,
+		expectedOutput:  []string{
+			"Lorem ipsum dolor sit amet, consectetur adipiscing",
+			" elit, sed do eiusmod tempor inc <clipped message>",
+		},
+	},
+	"Short multi-line message": {
+		inputText:       "I\ncan't\nget\nno\nsatisfaction!",
+		clipSplitLength: 50,
+		clippingMessage: "",
+		splitMax:        2,
+		expectedOutput:  []string{"I\ncan't\nget\nno\nsatisfaction!"},
+	},
+	"Long message containing UTF-8 multi-byte runes": {
+		inputText:       "人人生而自由，在尊嚴和權利上一律平等。 他們都具有理性和良知，應該以兄弟情誼的精神對待彼此。",
+		clipSplitLength: 50,
+		clippingMessage: "",
+		splitMax:        10,
+		expectedOutput:  []string{
+			"人人生而自由，在尊嚴和權利上一律", // Note: only 48 bytes!
+			"平等。 他們都具有理性和良知，應該", // Note: only 49 bytes!
+			"以兄弟情誼的精神對待彼此。",
+		},
+	},
+}
+
+func TestClipOrSplitMessage(t *testing.T) {
+	for testname, testcase := range clippingOrSplittingTestCases {
+		actualOutput := ClipOrSplitMessage(testcase.inputText, testcase.clipSplitLength, testcase.clippingMessage, testcase.splitMax)
+		assert.Equalf(t, testcase.expectedOutput, actualOutput, "'%s' testcase should give expected lines with clipping+splitting.", testname)
+		for _, splitLine := range testcase.expectedOutput {
+			byteLength := len([]byte(splitLine))
+			assert.True(t, byteLength <= testcase.clipSplitLength, "Splitted line '%s' of testcase '%s' should not exceed the maximum byte-length (%d vs. %d).", splitLine, testname, testcase.clipSplitLength, byteLength)
+		}
+	}
+}

--- a/matterbridge.toml.sample
+++ b/matterbridge.toml.sample
@@ -925,9 +925,16 @@ ShowTopicChange=false
 # Supported from the following bridges: slack
 SyncTopic=false
 
-#Message to show when a message is too big
-#Default "<clipped message>"
+# Message to show when a message is too big
+# Default "<clipped message>"
 MessageClipped="<clipped message>"
+
+# Before clipping, try to split messages into at most this many parts. 0 is treated like 1.
+# Be careful with large numbers, as this might cause flooding.
+# Example: A maximum telegram message of 4096 bytes is received. This requires 3 Discord
+# messages (each capped at a hardcoded 1950 bytes).
+# Default 1
+MessageSplitMaxCount=3
 
 ###################################################################
 #telegram section


### PR DESCRIPTION
Old behavior: Telegram user sends a huge 4096-byte message (the maximum permitted by Telegram), it gets clipped to 1950 bytes on Discord.

New havior: Set `MessageSplitMaxCount=3` as config option of the Bridge, and it instead sends up to three messages to Discord (each of maximum length)

Note that this handles editing correctly, both in the "bot user" and "webhooks" cases.

This PR combines well with #2123.

I have no write permissions to the wiki, so I cannot add the appropriate documentation there.