### PR TITLE
fix: update post types and include system removals in skip logic

### DIFF
--- a/bridge/mattermost/helpers.go
+++ b/bridge/mattermost/helpers.go
@@ -171,12 +171,24 @@ func (b *Bmattermost) sendWebhook(msg config.Message) (string, error) {
 }
 
 // skipMessages returns true if this message should not be handled
+//
 //nolint:gocyclo,cyclop
 func (b *Bmattermost) skipMessage(message *matterclient.Message) bool {
+
 	// Handle join/leave
-	if message.Type == "system_join_leave" ||
-		message.Type == "system_join_channel" ||
-		message.Type == "system_leave_channel" {
+	skipJoinMessageTypes := map[string]struct{}{
+		"system_join_leave":          {}, //deprecated for system_add_to_channel
+		"system_leave_channel":       {}, //deprecated for system_remove_from_channel
+		"system_join_channel":        {},
+		"system_add_to_channel":      {},
+		"system_remove_from_channel": {},
+		"system_add_to_team":         {},
+		"system_remove_from_team":    {},
+	}
+
+	// dirty hack to efficiently check if this element is in the map without writing a contains func
+	// can be replaced with native slice.contains with go 1.21
+	if _, ok := skipJoinMessageTypes[message.Type]; ok {
 		if b.GetBool("nosendjoinpart") {
 			return true
 		}


### PR DESCRIPTION
I believe that previously, these post types were grouped in these three categories, but have since been broken out to be more verbose.

I ran into this today as we have join/part as well as adding/removal from teams turned _off_, but found that when an Admin removes a user from the team, a different message type is generated.