### PR TITLE
Clear existing IRC event handlers before connecting to new ones

### DIFF
--- a/bridge/irc/handlers.go
+++ b/bridge/irc/handlers.go
@@ -122,6 +122,17 @@ func (b *Birc) handleNewConnection(client *girc.Client, event girc.Event) {
 	i := b.i
 	b.Nick = event.Params[0]
 
+	b.Log.Debug("Clearing handlers before adding in case of BNC reconnect")
+	i.Handlers.Clear("PRIVMSG")
+	i.Handlers.Clear("CTCP_ACTION")
+	i.Handlers.Clear(girc.RPL_TOPICWHOTIME)
+	i.Handlers.Clear(girc.NOTICE)
+	i.Handlers.Clear("JOIN")
+	i.Handlers.Clear("PART")
+	i.Handlers.Clear("QUIT")
+	i.Handlers.Clear("KICK")
+	i.Handlers.Clear("INVITE")
+
 	i.Handlers.AddBg("PRIVMSG", b.handlePrivMsg)
 	i.Handlers.AddBg("CTCP_ACTION", b.handlePrivMsg)
 	i.Handlers.Add(girc.RPL_TOPICWHOTIME, b.handleTopicWhoTime)


### PR DESCRIPTION
Clear IRC event handlers that we will be registering for the new connection before registering new handlers. This prevents duplicate event handlers in the case where we are connecting via a BNC and are seeing a reconnect. Attempting to clear handlers when none have been set is a no-op.

Fixes 42wim#1564
Co-authored-by: Andreas Vögele <andreas@andreasvoegele.com>