### PR TITLE
Move deprecated/inactive 3rd party bridges to their own sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,18 +115,20 @@ And more...
 ### 3rd party via matterbridge api
 
 - [Delta Chat](https://github.com/deltachat-bot/matterdelta)
+- [Minecraft](https://github.com/raws/mattercraft)
+- [Minecraft](https://gitlab.com/Programie/MatterBukkit)
+
+#### Past 3rd party projects
 - [Discourse](https://github.com/DeclanHoare/matterbabble)
 - [Facebook messenger](https://github.com/powerjungle/fbridge-asyncio)
 - [Facebook messenger](https://github.com/VictorNine/fbridge)
 - [Minecraft](https://github.com/elytra/MatterLink)
-- [Minecraft](https://github.com/raws/mattercraft)
-- [Minecraft](https://gitlab.com/Programie/MatterBukkit)
 - [Reddit](https://github.com/bonehurtingjuice/mattereddit)
-- [Counter-Strike, half-life and more](https://forums.alliedmods.net/showthread.php?t=319430)
-- [MatterAMXX](https://github.com/GabeIggy/MatterAMXX)
+- [MatterAMXX](https://github.com/andrewlindberg/MatterAMXX): [Counter-Strike, half-life and more](https://forums.alliedmods.net/showthread.php?t=319430)
 - [Vintage Story](https://github.com/NikkyAI/vs-matterbridge)
 - [Ultima Online Emulator](https://github.com/kuoushi/ServUO-Matterbridge)
 - [Teamspeak](https://github.com/Archeb/ts-matterbridge)
+
 
 ### API
 


### PR DESCRIPTION
Most of the bridges in the 3rd party section were deprecated or inactive for longer than 2 years. I moved these into their own section such that other people trying to set up bridges do not waste time clicking on all of these to see which ones worked