### PR TITLE
various improvements to attachment bridging

### DIFF
--- a/bridge/discord/handlers.go
+++ b/bridge/discord/handlers.go
@@ -98,14 +98,18 @@ func (b *Bdiscord) messageCreate(s *discordgo.Session, m *discordgo.MessageCreat
 		return
 	}
 
+
+	rmsg := config.Message{Account: b.Account, Avatar: "https://cdn.discordapp.com/avatars/" + m.Author.ID + "/" + m.Author.Avatar + ".jpg", UserID: m.Author.ID, ID: m.ID, Extra: make(map[string][]interface{}, 0)}
+
 	// add the url of the attachments to content
 	if len(m.Attachments) > 0 {
 		for _, attach := range m.Attachments {
-			m.Content = m.Content + "\n" + attach.URL
+			rmsg.Extra["file"] = append(rmsg.Extra["file"], config.FileInfo {
+				URL: attach.URL,
+			})
+			// m.Content = m.Content + "\n" + attach.URL
 		}
 	}
-
-	rmsg := config.Message{Account: b.Account, Avatar: "https://cdn.discordapp.com/avatars/" + m.Author.ID + "/" + m.Author.Avatar + ".jpg", UserID: m.Author.ID, ID: m.ID}
 
 	b.Log.Debugf("== Receiving event %#v", m.Message)
 
@@ -139,7 +143,7 @@ func (b *Bdiscord) messageCreate(s *discordgo.Session, m *discordgo.MessageCreat
 	}
 
 	// no empty messages
-	if rmsg.Text == "" {
+	if rmsg.Text == "" && len(rmsg.Extra["file"]) == 0 {
 		return
 	}
 

--- a/bridge/irc/handlers.go
+++ b/bridge/irc/handlers.go
@@ -50,18 +50,26 @@ func (b *Birc) handleFiles(msg *config.Message) bool {
 	if len(msg.Extra["file"]) == 0 {
 		return false
 	}
+
+	if msg.Text != "" {
+		b.Local <- config.Message{
+			Text:     msg.Text,
+			Username: msg.Username,
+			Channel:  msg.Channel,
+			Event:    msg.Event,
+		}
+	}
+
 	for _, f := range msg.Extra["file"] {
 		fi := f.(config.FileInfo)
+		var text = ""
 		if fi.Comment != "" {
-			msg.Text += fi.Comment + " : "
+			text += fi.Comment + " : "
 		}
 		if fi.URL != "" {
-			msg.Text = fi.URL
-			if fi.Comment != "" {
-				msg.Text = fi.Comment + " : " + fi.URL
-			}
+			text += fi.URL
 		}
-		b.Local <- config.Message{Text: msg.Text, Username: msg.Username, Channel: msg.Channel, Event: msg.Event}
+		b.Local <- config.Message{Text: text, Username: msg.Username, Channel: msg.Channel, Event: msg.Event}
 	}
 	return true
 }


### PR DESCRIPTION
briefly:
* discord attachments are kept in `Extra["file"]`
* xmpp attachments will properly display inline in most clients
* irc will not drop message body when sending an attachment

please see the full commit messages for more detail.