### PR TITLE
Update WhatsApp version number

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/42wim/matterbridge
+module github.com/IntGrah/matterbridge
 
 require (
 	github.com/Baozisoftware/qrcode-terminal-go v0.0.0-20170407111555-c0650d8dff0f

--- a/vendor/go.mau.fi/whatsmeow/store/clientpayload.go
+++ b/vendor/go.mau.fi/whatsmeow/store/clientpayload.go
@@ -74,7 +74,7 @@ func (vc WAVersionContainer) ProtoAppVersion() *waProto.ClientPayload_UserAgent_
 }
 
 // waVersion is the WhatsApp web client version
-var waVersion = WAVersionContainer{2, 2412, 50}
+var waVersion = WAVersionContainer{2, 3000, 1015853550}
 
 // waVersionHash is the md5 hash of a dot-separated waVersion
 var waVersionHash [16]byte


### PR DESCRIPTION
Fixes 42wim/matterbridge#2175.

Just update the WhatsApp version number.