### PR TITLE
Slack: auto-join channels regardless of legacy

### DIFF
--- a/bridge/slack/slack.go
+++ b/bridge/slack/slack.go
@@ -155,18 +155,6 @@ func (b *Bslack) JoinChannel(channel config.ChannelInfo) error {
 		return nil
 	}
 
-	// try to join a channel when in legacy
-	if b.legacy {
-		_, _, _, err := b.sc.JoinConversation(channel.Name)
-		if err != nil {
-			switch err.Error() {
-			case "name_taken", "restricted_action":
-			case "default":
-				return err
-			}
-		}
-	}
-
 	b.channels.populateChannels(false)
 
 	channelInfo, err := b.channels.getChannel(channel.Name)
@@ -179,9 +167,16 @@ func (b *Bslack) JoinChannel(channel config.ChannelInfo) error {
 		channel.Name = channelInfo.Name
 	}
 
-	// we can't join a channel unless we are using legacy tokens #651
-	if !channelInfo.IsMember && !b.legacy {
-		return fmt.Errorf("slack integration that matterbridge is using is not member of channel '%s', please add it manually", channelInfo.Name)
+	if !channelInfo.IsMember {
+		// try to join a channel
+		_, _, _, err := b.sc.JoinConversation(channel.Name)
+		if err != nil {
+			switch err.Error() {
+			case "name_taken", "restricted_action":
+			case "default":
+				return fmt.Errorf("slack integration that matterbridge is using is not member of channel '%s', please add it manually: %#v", channelInfo.Name, err)
+			}
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
Hi! I have not tested this code yet, very sorry, but it builds and I think it will allow auto-joining public channels regardless of whether the token is legacy-mode or not.

I am not sure of whether this logic makes sense. It looks like once upon a time some predecessor of the currently used join method would create a channel if missing, but the currently used [conversations.join](https://api.slack.com/methods/conversations.join) is documented to fail when there is no such channel. So I think it makes more sense to try to join the channel when the bot finds that it is not a member.

Anyway, please treat this more like an issue report with suggested direction of addressing the problem rather than a complete solution.