### PR TITLE
Whatsmeow lib update

### DIFF
--- a/bridge/whatsappmulti/handlers.go
+++ b/bridge/whatsappmulti/handlers.go
@@ -4,6 +4,7 @@
 package bwhatsapp
 
 import (
+	"context"
 	"fmt"
 	"mime"
 	"strings"
@@ -242,7 +243,8 @@ func (b *Bwhatsapp) handleImageMessage(msg *events.Message) {
 
 	b.Log.Debugf("Trying to download %s with type %s", filename, imsg.GetMimetype())
 
-	data, err := b.wc.Download(imsg)
+	// Fix: Add context.Background() as first parameter
+	data, err := b.wc.Download(context.Background(), imsg)
 	if err != nil {
 		b.Log.Errorf("Download image failed: %s", err)
 
@@ -309,7 +311,8 @@ func (b *Bwhatsapp) handleVideoMessage(msg *events.Message) {
 
 	b.Log.Debugf("Trying to download %s with size %#v and type %s", filename, imsg.GetFileLength(), imsg.GetMimetype())
 
-	data, err := b.wc.Download(imsg)
+	// Fix: Add context.Background() as first parameter
+	data, err := b.wc.Download(context.Background(), imsg)
 	if err != nil {
 		b.Log.Errorf("Download video failed: %s", err)
 
@@ -366,7 +369,8 @@ func (b *Bwhatsapp) handleAudioMessage(msg *events.Message) {
 
 	b.Log.Debugf("Trying to download %s with size %#v and type %s", filename, imsg.GetFileLength(), imsg.GetMimetype())
 
-	data, err := b.wc.Download(imsg)
+	// Fix: Add context.Background() as first parameter
+	data, err := b.wc.Download(context.Background(), imsg)
 	if err != nil {
 		b.Log.Errorf("Download video failed: %s", err)
 
@@ -420,7 +424,8 @@ func (b *Bwhatsapp) handleDocumentMessage(msg *events.Message) {
 
 	b.Log.Debugf("Trying to download %s with extension %s and type %s", filename, fileExt, imsg.GetMimetype())
 
-	data, err := b.wc.Download(imsg)
+	// Fix: Add context.Background() as first parameter
+	data, err := b.wc.Download(context.Background(), imsg)
 	if err != nil {
 		b.Log.Errorf("Download document message failed: %s", err)
 

--- a/bridge/whatsappmulti/helpers.go
+++ b/bridge/whatsappmulti/helpers.go
@@ -4,6 +4,7 @@
 package bwhatsapp
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -14,6 +15,7 @@ import (
 	"go.mau.fi/whatsmeow/store"
 	"go.mau.fi/whatsmeow/store/sqlstore"
 	"go.mau.fi/whatsmeow/types"
+	waLog "go.mau.fi/whatsmeow/util/log"
 )
 
 type ProfilePicInfo struct {
@@ -23,11 +25,13 @@ type ProfilePicInfo struct {
 }
 
 func (b *Bwhatsapp) reloadContacts() {
-	if _, err := b.wc.Store.Contacts.GetAllContacts(); err != nil {
+	// Fix: Add context.Background() as first parameter
+	if _, err := b.wc.Store.Contacts.GetAllContacts(context.Background()); err != nil {
 		b.Log.Errorf("error on update of contacts: %v", err)
 	}
 
-	allcontacts, err := b.wc.Store.Contacts.GetAllContacts()
+	// Fix: Add context.Background() as first parameter
+	allcontacts, err := b.wc.Store.Contacts.GetAllContacts(context.Background())
 	if err != nil {
 		b.Log.Errorf("error on update of contacts: %v", err)
 	}
@@ -136,12 +140,14 @@ func isGroupJid(identifier string) bool {
 func (b *Bwhatsapp) getDevice() (*store.Device, error) {
 	device := &store.Device{}
 
-	storeContainer, err := sqlstore.New("sqlite", "file:"+b.Config.GetString("sessionfile")+".db?_pragma=foreign_keys(1)&_pragma=busy_timeout=10000", nil)
+	// Fix: Add context.Background() as first parameter and waLog.Noop logger
+	storeContainer, err := sqlstore.New(context.Background(), "sqlite", "file:"+b.Config.GetString("sessionfile")+".db?_pragma=foreign_keys(1)&_pragma=busy_timeout=10000", waLog.Noop)
 	if err != nil {
 		return device, fmt.Errorf("failed to connect to database: %v", err)
 	}
 
-	device, err = storeContainer.GetFirstDevice()
+	// Fix: Add context.Background() as first parameter
+	device, err = storeContainer.GetFirstDevice(context.Background())
 	if err != nil {
 		return device, fmt.Errorf("failed to get device: %v", err)
 	}

--- a/bridge/whatsappmulti/whatsapp.go
+++ b/bridge/whatsappmulti/whatsapp.go
@@ -122,7 +122,8 @@ func (b *Bwhatsapp) Connect() error {
 
 	b.Log.Infoln("WhatsApp connection successful")
 
-	b.contacts, err = b.wc.Store.Contacts.GetAllContacts()
+	// Fix: Add context.Background() as first parameter
+	b.contacts, err = b.wc.Store.Contacts.GetAllContacts(context.Background())
 	if err != nil {
 		return errors.New("failed to get contacts: " + err.Error())
 	}

--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/writeas/go-strip-markdown v2.0.1+incompatible
 	github.com/yaegashi/msgraph.go v0.1.4
 	github.com/zfjagann/golang-ring v0.0.0-20220330170733-19bcea1b6289
-	go.mau.fi/whatsmeow v0.0.0-20240821142752-3d63c6fcc1a7
+	go.mau.fi/whatsmeow v0.0.0-20250527134344-0b502af800ee
 	golang.org/x/image v0.19.0
 	golang.org/x/oauth2 v0.22.0
 	golang.org/x/text v0.17.0


### PR DESCRIPTION
This brings the required whatsmeow library version up to most recent commit dated 27th May 2025.

The API has changed and expects the context to be passed as the first parameter.

Otherwise there are no other changes.

This has been tested on a live system and in the last 24 hours there appears to be no issues.