### PR TITLE
Add Puppet module

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,6 +359,7 @@ See [FAQ](https://github.com/42wim/matterbridge/wiki/FAQ)
 ## Related projects
 
 - [jwflory/ansible-role-matterbridge](https://galaxy.ansible.com/jwflory/matterbridge) (Ansible role to simplify deploying Matterbridge)
+- [puppet-matterbridge](https://github.com/voxpupuli/puppet-matterbridge) (Puppet module to deploy and manage Matterbridge)
 - [matterbridge autoconfig](https://github.com/patcon/matterbridge-autoconfig)
 - [matterbridge config viewer](https://github.com/patcon/matterbridge-heroku-viewer)
 - [matterbridge-heroku](https://github.com/cadecairos/matterbridge-heroku)


### PR DESCRIPTION
We've been using this module in production to manage our bridges between IRC and two Slack instances for several years now.