### PR TITLE
Ignore discord updates when the message hasn't been edited in the last 6 hours

### DIFF
--- a/bridge/discord/handlers.go
+++ b/bridge/discord/handlers.go
@@ -1,6 +1,8 @@
 package bdiscord
 
 import (
+	"time"
+
 	"github.com/42wim/matterbridge/bridge/config"
 	"github.com/bwmarrin/discordgo"
 	"github.com/davecgh/go-spew/spew"
@@ -63,6 +65,13 @@ func (b *Bdiscord) messageTyping(s *discordgo.Session, m *discordgo.TypingStart)
 	b.Remote <- rmsg
 }
 
+// Discord sends spurious updates for messages that haven't been edited, or
+// haven't been edited recently. Messages from as far back as 5 years ago have
+// been observed to be updated, always with a URL or embedded content.
+//
+// These need to be ignored because it's confusing when out of date messages
+// are bridged as new messages with no context to protocols that don't support
+// edits. Edited messages normally arrive as updates immediately.
 func (b *Bdiscord) messageUpdate(s *discordgo.Session, m *discordgo.MessageUpdate) { //nolint:unparam
 	if m.GuildID != b.guildID {
 		b.Log.Debugf("Ignoring messageUpdate because it originates from a different guild")
@@ -73,6 +82,12 @@ func (b *Bdiscord) messageUpdate(s *discordgo.Session, m *discordgo.MessageUpdat
 	}
 	// only when message is actually edited
 	if m.Message.EditedTimestamp != nil {
+		// message must have been edited recently
+		delay := time.Now().Sub(*m.Message.EditedTimestamp)
+		if delay >= time.Duration(6) * time.Hour {
+			return
+		}
+
 		b.Log.Debugf("Sending edit message")
 		m.Content += b.GetString("EditSuffix")
 		msg := &discordgo.MessageCreate{


### PR DESCRIPTION
Discord sends spurious updates for messages that haven't been edited, or haven't been edited recently. Messages from as far back as 5 years ago have been observed to be updated, always with a URL or embedded content.

These need to be ignored because it's confusing when out of date messages are bridged as new messages with no context to protocols that don't support edits. Edited messages normally arrive as updates immediately.